### PR TITLE
BluetoothStartupHelper

### DIFF
--- a/src/com/idevicesinc/sweetblue/BleManager.java
+++ b/src/com/idevicesinc/sweetblue/BleManager.java
@@ -1760,7 +1760,7 @@ public class BleManager
 				intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
 				Uri uri = Uri.fromParts("package", callingActivity.getPackageName(), null);
 				intent.setData(uri);
-				callingActivity.startActivity(intent);
+				callingActivity.startActivityForResult(intent, requestCode);
 			}
 			else
 			{

--- a/src/com/idevicesinc/sweetblue/BleManager.java
+++ b/src/com/idevicesinc/sweetblue/BleManager.java
@@ -1748,13 +1748,16 @@ public class BleManager
 	private static final String s_locationPermissionKey = "location_permission_key";
 
 	/**
-	 * Returns <code>false</code> if the app has never requested Location Permissions and shown the Location Permission dialog. This method is used to weed out the false
-	 * negative from {@link Activity#shouldShowRequestPermissionRationale(String)} when the Location Permission has never been requested.
+	 * Returns <code>true</code> if the app has never shown a request Location Permissions dialog or has shown a request Location Permission dialog and the user has yet to select "Never ask again". This method is used to weed out the false
+	 * negative from {@link Activity#shouldShowRequestPermissionRationale(String)} when the Location Permission has never been requested. Make sure to use this in conjunction with {@link #isLocationEnabledForScanning_byRuntimePermissions()}
+	 * which will tell you if permissions are already enabled.
 	 */
-	public boolean alreadyRequestedLocationPermission(Activity callingActivity)
+	public boolean willLocationSystemDialogBeShown(Activity callingActivity)
 	{
 		SharedPreferences preferences = callingActivity.getSharedPreferences(s_locationPermissionNamespace, Context.MODE_PRIVATE);
-		return preferences.getBoolean(s_locationPermissionKey, false);
+		boolean hasNeverAskAgainBeenSelected = !callingActivity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION);//Call only returns true if Location permission has been previously denied. Returns false if "Never ask again" has been selected
+		boolean hasLocationPermissionSystemDialogShownOnce = preferences.getBoolean(s_locationPermissionKey, false);
+		return (!hasLocationPermissionSystemDialogShownOnce) || (hasLocationPermissionSystemDialogShownOnce && !hasNeverAskAgainBeenSelected);
 	}
 
 	/**
@@ -1770,7 +1773,7 @@ public class BleManager
 	{
 		if( Utils.isMarshmallow() )
 		{
-			if(!isLocationEnabledForScanning_byRuntimePermissions() && !callingActivity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION) && alreadyRequestedLocationPermission(callingActivity))
+			if(!isLocationEnabledForScanning_byRuntimePermissions() && !willLocationSystemDialogBeShown(callingActivity))
 			{
 				Intent intent = new Intent();
 				intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);

--- a/src/com/idevicesinc/sweetblue/BleManager.java
+++ b/src/com/idevicesinc/sweetblue/BleManager.java
@@ -17,6 +17,7 @@ import android.bluetooth.le.ScanCallback;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.DeadObjectException;
 import android.os.Handler;
@@ -1753,8 +1754,18 @@ public class BleManager
 	{
 		if( Utils.isMarshmallow() )
 		{
-			callingActivity.requestPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, requestCode);
-		}
+			if(!isLocationEnabledForScanning_byRuntimePermissions() && !callingActivity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION))
+			{
+				Intent intent = new Intent();
+				intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+				Uri uri = Uri.fromParts("package", callingActivity.getPackageName(), null);
+				intent.setData(uri);
+				callingActivity.startActivity(intent);
+			}
+			else
+			{
+				callingActivity.requestPermissions(new String[]{Manifest.permission.ACCESS_COARSE_LOCATION}, requestCode);
+			}		}
 		else
 		{
 			m_logger.w("BleManager.turnOnLocationWithIntent_forPermissions() is only applicable for API levels 23 and above so this method does nothing.");

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -64,7 +64,8 @@ public class BluetoothEnabler
             LOCATION_PERMISSION,
 
             /**
-             * Used when checking if the device needs Location services turned on and enabling Location services if they are disabled.
+             * Used when checking if the device needs Location services turned on and enabling Location services if they are disabled. This step isn't necessarily needed for overall
+             * Bluetooth scanning. It is only needed for Bluetooth Low Energy scanning in {@link android.os.Build.VERSION_CODES#M}; otherwise, SweetBlue will default to classic scanning.
              */
             LOCATION_SERVICES;
 

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -305,13 +305,6 @@ public class BluetoothEnabler
      */
     public static class DefaultBluetoothEnablerListener implements BluetoothEnablerListener
     {
-        private BleManager m_bleMngr;
-
-        public DefaultBluetoothEnablerListener(BleManager manager)
-        {
-            m_bleMngr = manager;
-        }
-
         @Override
         public Please onEvent(BluetoothEnablerEvent e)
         {
@@ -323,16 +316,15 @@ public class BluetoothEnabler
             {
                 if(e.status() == Status.ALREADY_ENABLED || e.status() == Status.ENABLED)
                 {
-//                    return Please.doNext().withDialog("Location permissions are needed for Bluetooth LE scan to show available devices. If you would like to see your devices please allow the Location permission.").withImplicitActivityResultHandling();
-                    if(!m_bleMngr.isLocationEnabledForScanning_byRuntimePermissions() && ! m_bleMngr.isLocationEnabledForScanning_byOsServices())
+                    if(!e.isEnabled(Stage.LOCATION_SERVICES) && !e.isEnabled(Stage.LOCATION_PERMISSION))
                     {
                         return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires location permission to the app to be able to scan for Bluetooth devices.\n\nMarshmallow also requires Location Services to improve Bluetooth device discovery.  While it is not required for use in this app, it is recommended to better discover devices.\n\nPlease accept to allow Location Permission and Services");
                     }
-                    else if(!m_bleMngr.isLocationEnabledForScanning_byRuntimePermissions())
+                    else if(!e.isEnabled(Stage.LOCATION_PERMISSION))
                     {
-                        return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires location to be able to scan for Bluetooth devices. Please accept to allow Location Permission");
+                        return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires location permission to be able to scan for Bluetooth devices. Please accept to allow Location Permission");
                     }
-                    else if(!m_bleMngr.isLocationEnabledForScanning_byOsServices())
+                    else if(!e.isEnabled(Stage.LOCATION_SERVICES))
                     {
                         return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires Location Services for improved Bluetooth device scanning. While it is not required, it is recommended that Location Services are turned on to improve device discovery");
                     }
@@ -383,7 +375,7 @@ public class BluetoothEnabler
      */
     public BluetoothEnabler(Activity activity)
     {
-        this(activity, new DefaultBluetoothEnablerListener(BleManager.get(activity)));
+        this(activity, new DefaultBluetoothEnablerListener());
     }
 
     /**

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -260,7 +260,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * Pause the enabler. Call {@see com.idevicesinc.sweetblue.utils.BluetoothEnabler#resume(Please)} to continue the process.
+             * Pause the enabler. Call {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler#resume(com.idevicesinc.sweetblue.utils.BluetoothEnabler.BluetoothEnablerListener.Please)} to continue the process.
              */
             public static Please pause()
             {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -196,7 +196,12 @@ public class BluetoothEnabler {
         Please onEvent(final BluetoothEnablerEvent e);
     }
 
-    private final BluetoothEnablerListener DEFAULT_STARTUP_LISTENER = new BluetoothEnablerListener() {
+    public static class DefaultBluetoothEnablerListener implements BluetoothEnablerListener
+    {
+
+        public DefaultBluetoothEnablerListener()
+        {}
+
         @Override
         public Please onEvent(BluetoothEnablerEvent e) {
             if(e.stage() == Stage.START)
@@ -248,13 +253,12 @@ public class BluetoothEnabler {
             }
             return Please.doNext();
         }
-    };
-
+    }
 
     private final BleManager m_bleManager;
     private final BluetoothEnablerListener m_startupListener;
 
-    private Activity m_passedActivity;
+    private final Activity m_passedActivity;
 
     private BluetoothEnablerListener.Please m_lastPlease;
     private BluetoothEnablerListener.Stage m_currentStage;
@@ -273,7 +277,7 @@ public class BluetoothEnabler {
 
         m_currentStage = BluetoothEnablerListener.Stage.START;
         m_currentEvent = new BluetoothEnablerListener.BluetoothEnablerEvent(m_currentStage);
-        m_startupListener = DEFAULT_STARTUP_LISTENER;
+        m_startupListener = new DefaultBluetoothEnablerListener();
         nextStage();
     }
 

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -323,6 +323,12 @@ public class BluetoothEnabler
         @Override
         public Please onEvent(BluetoothEnablerEvent e)
         {
+            final String locationPermissionAndServicesNeedEnablingString = "Android Marshmallow (6.0+) requires Location Permission to the app to be able to scan for Bluetooth devices.\n\nMarshmallow also requires Location Services to improve Bluetooth device discovery.  While it is not required for use in this app, it is recommended to better discover devices.\n\nPlease accept to allow Location Permission and Services";
+            final String locationPermissionNeedEnablingString = "Android Marshmallow (6.0+) requires Location Permission to be able to scan for Bluetooth devices. Please accept to allow Location Permission.";
+            final String locationServicesNeedEnablingString = "Android Marshmallow (6.0+) requires Location Services for improved Bluetooth device scanning. While it is not required, it is recommended that Location Services are turned on to improve device discovery.";
+            final String locationPermissionToastString = "Please click the Permissions button, then enable Location, then press back";
+            final String locationServicesToastString = "Please enable Location Services then press back button";
+
             if(e.nextStage() == Stage.BLUETOOTH)
             {
                 return Please.doNext().withImplicitActivityResultHandling();
@@ -333,20 +339,31 @@ public class BluetoothEnabler
                 {
                     if(!e.isEnabled(Stage.LOCATION_SERVICES) && !e.isEnabled(Stage.LOCATION_PERMISSION))
                     {
-                        return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires Location Permission to the app to be able to scan for Bluetooth devices.\n\nMarshmallow also requires Location Services to improve Bluetooth device discovery.  While it is not required for use in this app, it is recommended to better discover devices.\n\nPlease accept to allow Location Permission and Services").withToast("Please click the Permissions button, then enable Location, then press back");
+                        if(BleManager.get(e.activity()).willLocationSystemDialogBeShown(e.activity()))
+                        {
+                            return Please.doNext().withImplicitActivityResultHandling().withDialog(locationPermissionAndServicesNeedEnablingString);
+                        }
+                        else
+                        {
+                            return Please.doNext().withImplicitActivityResultHandling().withDialog(locationPermissionAndServicesNeedEnablingString).withToast(locationPermissionToastString);
+                        }
                     }
                     else if(!e.isEnabled(Stage.LOCATION_PERMISSION))
                     {
-                        return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires Location Permission to be able to scan for Bluetooth devices. Please accept to allow Location Permission.").withToast("Please click the Permissions button, then enable Location, then press back");
+                        if(BleManager.get(e.activity()).willLocationSystemDialogBeShown(e.activity()))
+                        {
+                            return Please.doNext().withImplicitActivityResultHandling().withDialog(locationPermissionNeedEnablingString);
+                        }
+                        else
+                        {
+                            return Please.doNext().withImplicitActivityResultHandling().withDialog(locationPermissionNeedEnablingString).withToast(locationPermissionToastString);
+                        }
                     }
                     else if(!e.isEnabled(Stage.LOCATION_SERVICES))
                     {
-                        return Please.doNext().withImplicitActivityResultHandling().withDialog("Android Marshmallow (6.0+) requires Location Services for improved Bluetooth device scanning. While it is not required, it is recommended that Location Services are turned on to improve device discovery.").withToast("Please enable Location Services then press back button");
+                        return Please.doNext().withImplicitActivityResultHandling().withDialog(locationServicesNeedEnablingString).withToast(locationServicesToastString);
                     }
-                    else
-                    {
-                        return Please.stop();
-                    }
+                    return Please.stop();
                 }
                 else if(e.status() == Status.CANCELLED_BY_DIALOG || e.status() == Status.CANCELLED_BY_INTENT)
                 {
@@ -359,7 +376,7 @@ public class BluetoothEnabler
                 {
                     if(!e.isEnabled(Stage.LOCATION_SERVICES))
                     {
-                        return Please.doNext().withImplicitActivityResultHandling().withToast("Please enable Location Services then press back button");
+                        return Please.doNext().withImplicitActivityResultHandling().withToast(locationServicesToastString);
                     }
                     return Please.doNext().withImplicitActivityResultHandling();
                 }
@@ -632,14 +649,7 @@ public class BluetoothEnabler
     {
         if(m_lastPlease.shouldShowToast() && !wasCancelledByDialog)
         {
-            if(m_currentStage == BluetoothEnablerListener.Stage.BLUETOOTH && !m_passedActivity.shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_COARSE_LOCATION))
-            {
-                Toast.makeText(m_passedActivity, m_lastPlease.m_toastText, Toast.LENGTH_LONG).show();
-            }
-            else if(m_currentStage != BluetoothEnablerListener.Stage.BLUETOOTH)
-            {
-                Toast.makeText(m_passedActivity, m_lastPlease.m_toastText, Toast.LENGTH_LONG).show();
-            }
+            Toast.makeText(m_passedActivity, m_lastPlease.m_toastText, Toast.LENGTH_LONG).show();
         }
 
         if(m_lastPlease.m_stateCode == BluetoothEnablerListener.Please.PAUSE)

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -24,7 +24,7 @@ public class BluetoothEnabler
 {
 
     /**
-     * Provide an implementation to {@link BluetoothEnabler#BluetoothEnabler#BluetoothEnabler(Activity, BluetoothEnablerListener)} to receive callbacks or simply use the provided class
+     * Provide an implementation to {@link BluetoothEnabler#BluetoothEnabler(Activity, BluetoothEnablerListener)} to receive callbacks or simply use the provided class
      * {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler.DefaultBluetoothEnablerListener} by caling {@link BluetoothEnabler#BluetoothEnabler(Activity)}. This listener will be the main
      * way of handling different enabling events and their results.
      *
@@ -260,7 +260,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * Pause the enabler. Call {@link #resume(Please)} to continue the process.
+             * Pause the enabler. Call {@link BluetoothEnabler#resume(Please)} to continue the process.
              */
             public static Please pause()
             {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -168,6 +168,7 @@ public class BluetoothEnabler {
             final static int DO_NEXT = 0;
             final static int SKIP_NEXT = 1;
             final static int END = 3;
+            final static int PAUSE = 4;
 
             private final static int NULL_REQUEST_CODE = 51214; //Large random int because we need to make sure that there is low probability that the user is using the same
             private final int m_stateCode;
@@ -188,7 +189,7 @@ public class BluetoothEnabler {
 
             private boolean shouldPopDialog()
             {
-                return m_dialogText.equals("") ? false : true;
+                return m_dialogText.equals("") || m_stateCode == PAUSE ? false : true;
             }
 
             /**
@@ -213,6 +214,14 @@ public class BluetoothEnabler {
             public static Please stop()
             {
                 return new Please(END);
+            }
+
+            /**
+             * Pause the enabler. Call {@link #resume(Please)} to continue the process.
+             */
+            public static Please pause()
+            {
+                return new Please(PAUSE);
             }
 
             /**
@@ -248,7 +257,8 @@ public class BluetoothEnabler {
     }
 
     /**
-     *
+     * A default implementation of BluetoothEnablerListener used in {@link BluetoothEnabler#BluetoothEnabler(Activity)}. It provides a
+     * basic implementation for use/example and can be overridden.
      */
     public static class DefaultBluetoothEnablerListener implements BluetoothEnablerListener
     {
@@ -481,7 +491,11 @@ public class BluetoothEnabler {
 
     private void finishPleaseResponse(boolean wasCancelledByDialog)
     {
-        if(m_lastPlease.m_stateCode == BluetoothEnablerListener.Please.DO_NEXT )
+        if(m_lastPlease.m_stateCode == BluetoothEnablerListener.Please.PAUSE)
+        {
+
+        }
+        else if(m_lastPlease.m_stateCode == BluetoothEnablerListener.Please.DO_NEXT )
         {
             m_currentStage = m_currentStage.next();
             BluetoothEnablerListener.BluetoothEnablerEvent nextEvent = wasCancelledByDialog ? new BluetoothEnablerListener.BluetoothEnablerEvent(m_currentStage, BluetoothEnablerListener.Status.CANCELLED_BY_DIALOG) : new BluetoothEnablerListener.BluetoothEnablerEvent(m_currentStage);
@@ -550,6 +564,15 @@ public class BluetoothEnabler {
                 }
             }
         }
+    }
+
+    /**
+     * Resume the enabler with the given Please. Enabler will continue where is left off.
+     */
+    public void resume(BluetoothEnablerListener.Please please)
+    {
+        m_lastPlease = please;
+        handlePleaseResponse();
     }
 }
 

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -268,7 +268,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * If the next stage isn't skipped or {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler.BluetoothEnablerListener.Status#ALREADY_ENABLED} then pop a dialog before
+             * If the next stage isn't skipped or {@see com.idevicesinc.sweetblue.utils.BluetoothEnabler.BluetoothEnablerListener.Status#ALREADY_ENABLED} then pop a dialog before
              */
             public Please withDialog(String message)
             {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -260,7 +260,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * Pause the enabler. Call {@link BluetoothEnabler#resume(Please)} to continue the process.
+             * Pause the enabler. Call {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler#resume(Please)} to continue the process.
              */
             public static Please pause()
             {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -20,7 +20,6 @@ import com.idevicesinc.sweetblue.annotations.Advanced;
  */
 public class BluetoothEnabler
 {
-
     /**
      * Provide an implementation to {@link BluetoothEnabler#BluetoothEnabler#BluetoothEnabler(Activity, BluetoothEnablerListener)} to receive callbacks or simply use the provided class
      * {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler.DefaultBluetoothEnablerListener} by caling {@link BluetoothEnabler#BluetoothEnabler(Activity)}. This listener will be the main
@@ -168,20 +167,7 @@ public class BluetoothEnabler
              */
             public boolean isEnabled(Stage stage)
             {
-                BleManager bleManager = BleManager.get(m_activity);
-                if(stage == BluetoothEnablerListener.Stage.BLUETOOTH)
-                {
-                    return bleManager.isBleSupported() && bleManager.is(BleManagerState.ON);
-                }
-                else if(stage == BluetoothEnablerListener.Stage.LOCATION_PERMISSION)
-                {
-                    return bleManager.isLocationEnabledForScanning_byRuntimePermissions();
-                }
-                else if(stage == BluetoothEnablerListener.Stage.LOCATION_SERVICES)
-                {
-                    return bleManager.isLocationEnabledForScanning_byOsServices();
-                }
-                return true;
+                return BluetoothEnabler.isEnabled(BleManager.get(m_activity), stage);
             }
 
             @Override public String toString()
@@ -356,6 +342,24 @@ public class BluetoothEnabler
             //This will handle any SKIPPED steps since it will fall through all the if/else above
             return Please.doNext();
         }
+    }
+
+
+    private static boolean isEnabled(BleManager bleManager, BluetoothEnablerListener.Stage stage)
+    {
+        if(stage == BluetoothEnablerListener.Stage.BLUETOOTH)
+        {
+            return bleManager.isBleSupported() && bleManager.is(BleManagerState.ON);
+        }
+        else if(stage == BluetoothEnablerListener.Stage.LOCATION_PERMISSION)
+        {
+            return bleManager.isLocationEnabledForScanning_byRuntimePermissions();
+        }
+        else if(stage == BluetoothEnablerListener.Stage.LOCATION_SERVICES)
+        {
+            return bleManager.isLocationEnabledForScanning_byOsServices();
+        }
+        return true;
     }
 
     private final BleManager m_bleManager;
@@ -679,20 +683,7 @@ public class BluetoothEnabler
      */
     public boolean isEnabled(BluetoothEnablerListener.Stage stage)
     {
-
-        if(stage == BluetoothEnablerListener.Stage.BLUETOOTH)
-        {
-            return m_bleManager.isBleSupported() && m_bleManager.is(BleManagerState.ON);
-        }
-        else if(stage == BluetoothEnablerListener.Stage.LOCATION_PERMISSION)
-        {
-            return m_bleManager.isLocationEnabledForScanning_byRuntimePermissions();
-        }
-        else if(stage == BluetoothEnablerListener.Stage.LOCATION_SERVICES)
-        {
-            return m_bleManager.isLocationEnabledForScanning_byOsServices();
-        }
-        return true;
+        return isEnabled(m_bleManager, stage);
     }
 
     /**

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -260,7 +260,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * Pause the enabler. Call {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler#resume(Please)} to continue the process.
+             * Pause the enabler. Call {@see com.idevicesinc.sweetblue.utils.BluetoothEnabler#resume(Please)} to continue the process.
              */
             public static Please pause()
             {
@@ -268,7 +268,7 @@ public class BluetoothEnabler
             }
 
             /**
-             * If the next stage isn't skipped or {@see com.idevicesinc.sweetblue.utils.BluetoothEnabler.BluetoothEnablerListener.Status#ALREADY_ENABLED} then pop a dialog before
+             * If the next stage isn't skipped or {@link com.idevicesinc.sweetblue.utils.BluetoothEnabler.BluetoothEnablerListener.Status#ALREADY_ENABLED} then pop a dialog before
              */
             public Please withDialog(String message)
             {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothEnabler.java
@@ -140,6 +140,9 @@ public class BluetoothEnabler
             }
             private final Stage m_stage;
 
+            /**
+             * Returns the {@link Activity} associated with the Event
+             */
             public Activity activity()
             {
                 return m_activity;
@@ -343,7 +346,6 @@ public class BluetoothEnabler
             return Please.doNext();
         }
     }
-
 
     private static boolean isEnabled(BleManager bleManager, BluetoothEnablerListener.Stage stage)
     {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
@@ -1,6 +1,7 @@
 package com.idevicesinc.sweetblue.utils;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 
 import com.idevicesinc.sweetblue.BleManager;
@@ -152,7 +153,9 @@ public class BluetoothStartupHelper {
         }
     };
 
-    private BleManager m_bleManager;
+    private AlertDialog.Builder m_reasonDialogBuilder;
+
+    private final BleManager m_bleManager;
     private final BluetoothStartupHelperListener m_startupListener;
 
     private BluetoothStartupHelperListener.Please m_lastPlease;
@@ -172,9 +175,7 @@ public class BluetoothStartupHelper {
     {
         if(m_currentEvent.stage() == BluetoothStartupHelperListener.EnablingStage.START)
         {
-            m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
-            m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-            handlePleaseResponse();
+            updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
         }
         else if(m_currentStage == BluetoothStartupHelperListener.EnablingStage.ENABLING_BLUETOOTH)
         {
@@ -188,18 +189,14 @@ public class BluetoothStartupHelper {
             }
             else
             {
-                m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
-                m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                handlePleaseResponse();
+                updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
             }
         }
         else if(m_currentStage == BluetoothStartupHelperListener.EnablingStage.REQUESTING_LOCATION_PERMISSION)
         {
             if(!Utils.isMarshmallow())
             {
-                m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.NOT_NEEDED);
-                m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                handlePleaseResponse();
+                updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.NOT_NEEDED);
             }
             else
             {
@@ -209,9 +206,7 @@ public class BluetoothStartupHelper {
                 }
                 else
                 {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
-                    m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                    handlePleaseResponse();
+                    updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
                 }
             }
         }
@@ -222,9 +217,7 @@ public class BluetoothStartupHelper {
                 m_bleManager.turnOnLocationWithIntent_forOsServices((Activity) m_lastPlease.context(), m_lastPlease.requestCode());
             }
             else{
-                m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
-                m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                handlePleaseResponse();
+                updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ALREADY_ENABLED);
             }
         }
     }
@@ -251,6 +244,13 @@ public class BluetoothStartupHelper {
         }
     }
 
+    private void updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status newStatus)
+    {
+        m_currentEvent.setEventStatus(newStatus);
+        m_lastPlease = m_startupListener.onEvent(m_currentEvent);
+        handlePleaseResponse();
+    }
+
     public void onActivityOrPermissionResult(int requestCode)
     {
         if(requestCode == m_lastPlease.requestCode());
@@ -259,50 +259,36 @@ public class BluetoothStartupHelper {
             {
                if(m_bleManager.isBleSupported() && !m_bleManager.is(BleManagerState.ON))
                {
-                   m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
-                   m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                   handlePleaseResponse();
+                   updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
                }
                 else
                {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ENABLED);
-                   m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                   handlePleaseResponse();
+                   updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ENABLED);
                }
             }
             else if(m_currentStage == BluetoothStartupHelperListener.EnablingStage.REQUESTING_LOCATION_PERMISSION)
             {
                 if(!m_bleManager.isLocationEnabledForScanning_byRuntimePermissions())
                 {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
-                    m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                    handlePleaseResponse();
+                    updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
                 }
                 else
                 {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ENABLED);
-                    m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                    handlePleaseResponse();
+                    updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ENABLED);
                 }
             }
             else if(m_currentStage == BluetoothStartupHelperListener.EnablingStage.ENABLING_LOCATION_SERVICES)
             {
                 if(!m_bleManager.isLocationEnabledForScanning_byOsServices())
                 {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
-                    m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                    handlePleaseResponse();
+                    updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.NEEDS_ENABLING);
                 }
                 else
                 {
-                    m_currentEvent.setEventStatus(BluetoothStartupHelperListener.Status.ENABLED);
-                    m_lastPlease = m_startupListener.onEvent(m_currentEvent);
-                    handlePleaseResponse();
+                    updateEventStatusAndPassEventToUser(BluetoothStartupHelperListener.Status.ENABLED);
                 }
-
             }
         }
     }
-
 }
 

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
@@ -3,6 +3,7 @@ package com.idevicesinc.sweetblue.utils;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 
 import com.idevicesinc.sweetblue.BleManager;
 import com.idevicesinc.sweetblue.BleManagerState;
@@ -94,6 +95,7 @@ public class BluetoothStartupHelper {
             final Context m_context;
             private final int m_requestCode;
             private final int m_stateCode;
+            private String m_dialogText = "";
 
             private Please(Context context, int stateCode, int requestCode)
             {
@@ -115,6 +117,16 @@ public class BluetoothStartupHelper {
             Context context()
             {
                 return m_context;
+            }
+
+            String dialogText()
+            {
+                return m_dialogText;
+            }
+
+            boolean shouldPopDialog()
+            {
+                return m_dialogText.equals("") ? false : true;
             }
 
             public static Please doNext(Context context)
@@ -140,6 +152,12 @@ public class BluetoothStartupHelper {
             public static Please stop(Context context)
             {
                 return new Please(context, END, NULL_REQUEST_CODE);
+            }
+
+            public Please withDialog(String message)
+            {
+                m_dialogText = message;
+                return this;
             }
         }
 
@@ -223,6 +241,26 @@ public class BluetoothStartupHelper {
     }
 
     public void handlePleaseResponse()
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(m_lastPlease.context());
+        if(m_lastPlease.shouldPopDialog())
+        {
+            builder.setMessage(m_lastPlease.dialogText());
+            builder.setNeutralButton("OK", new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    finishPleaseResponse();
+                }
+            });
+            builder.show();
+        }
+        else
+        {
+            finishPleaseResponse();
+        }
+    }
+
+    public void finishPleaseResponse()
     {
         if(m_lastPlease.stateCode() == BluetoothStartupHelperListener.Please.DO_NEXT || m_lastPlease.stateCode() == BluetoothStartupHelperListener.Please.DO_NEXT_WITH_REQUEST_CODE)
         {

--- a/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
+++ b/src/com/idevicesinc/sweetblue/utils/BluetoothStartupHelper.java
@@ -1,0 +1,339 @@
+package com.idevicesinc.sweetblue.utils;
+
+import android.app.Activity;
+import android.content.pm.PackageManager;
+
+import com.idevicesinc.sweetblue.BleManager;
+import com.idevicesinc.sweetblue.BleManagerState;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * BluetoothStartupHelper is used to handle the new logic that is introduced with {@link android.os.Build.VERSION_CODES#M}.  With {@link android.os.Build.VERSION_CODES#M} you need might need to request
+ * {@link android.Manifest.permission#ACCESS_COARSE_LOCATION} or {@link android.Manifest.permission#ACCESS_FINE_LOCATION} at runtime (behavior isn't too consistent)
+ * as well as make sure that the user has turned on location services on their device.
+ * <br><br>
+ * BluetoothStartupHelper will first make sure that
+ *
+ */
+public class BluetoothStartupHelper {
+
+    public static interface BluetoothStartupHelperListener
+    {
+        public static enum EnablingStage
+        {
+            ENABLE_BLUETOOTH,
+            ENABLE_BLUETOOTH_RESPONSE,
+            REQUEST_LOCATION_PERMISSION,
+            REQUEST_LOCATION_PERMISSION_RESPONSE,
+            ENABLE_LOCATION_SERVICES,
+            DONE;
+
+            EnablingStage nextStage()
+            {
+                return values()[ordinal() + 1];
+            }
+        }
+
+        public static enum Status
+        {
+            CANCELLED_BY_DIALOG,
+            CANCELLED_BY_INTENT,
+            ALREADY_ENABLED,
+            NOT_NEEDED,
+            NEED_RESPONSE,
+            ENABLED;
+        }
+
+        public static class BluetoothStartupEvent extends Event
+        {
+            public EnablingStage stage(){ return m_stage;}
+            private final EnablingStage m_stage;
+
+//            public EnablingStage nextStage(){return m_stage.nextStage();}
+
+            private final HashMap<BluetoothStartupEvent, Status> m_events;
+
+            BluetoothStartupEvent(BleManager bleManager, EnablingStage stage)
+            {
+                m_stage = stage;
+                populateStatusForStages(bleManager);
+            }
+
+            BluetoothStartupEvent(BleManager bleManager)
+            {
+                m_stage = EnablingStage.ENABLE_BLUETOOTH;
+                populateStatusForStages(bleManager);
+            }
+
+            private void populateStatusForStages(BleManager manager)
+            {
+
+            }
+
+            @Override public String toString()
+            {
+                return Utils_String.toString
+                (
+                        this.getClass(),
+                        "stage", stage()
+                );
+            }
+        }
+
+        public static class Please
+        {
+            private final static int NULL_REQUEST_CODE = 400; //Fix this to a better int
+            final Activity m_activity;
+            final int m_requestCode;
+            final BluetoothStartupHelperListener m_bluetoothStartupListener;
+            final EnablingStage m_stage;
+
+            private Please(Activity activity, int requestCode, EnablingStage stage, BluetoothStartupHelperListener startupListener )
+            {
+                m_activity = activity;
+                m_requestCode = requestCode;
+                m_stage = stage;
+                m_bluetoothStartupListener = startupListener;
+            }
+
+            public static Please doNext()
+            {
+                return new Please(null, NULL_REQUEST_CODE, );
+            }
+
+            public static Please doNextWithRequestCode(Activity activity, int requestCode)
+            {
+                return new Please(activity,, requestCode, null);
+            }
+
+        }
+
+        Please onEvent(final BluetoothStartupEvent e);
+    }
+
+    private static final BluetoothStartupHelperListener DEFAULT_STARTUP_LISTENER = new BluetoothStartupHelperListener() {
+        private final int DEFAULT_PERMISSION_REQUEST_CODE = 486016991;
+        private final int DEFUALT_SETTING_REQUEST_CODE = 91042469;
+        @Override
+        public Please onEvent(BluetoothStartupEvent e) {
+            return Please.doNextWithRequestCode();
+        }
+    };
+
+    public BluetoothStartupHelper(BleManager bleManager, BluetoothStartupHelperListener startupListener)
+    {
+        BluetoothStartupHelperListener.Please please = BluetoothStartupHelperListener.Please.doNext();
+    }
+
+
+    /**
+     * Provide an implementation to
+     */
+    @com.idevicesinc.sweetblue.annotations.Lambda
+    public static interface BluetoothEnabledListener
+    {
+        void bluetoothWasEnabled();
+        void bluetoothStillDisabled();
+    }
+
+    public static interface LocationPermissionListener
+    {
+        void locationPermissionGranted();
+        void locationPermissionDenied();
+    }
+
+    public static interface LocationServicesListener
+    {
+        void locationServicesEnabled();
+        void locationServicesStillDisabled();
+    }
+
+    private final BleManager m_bleManager;
+    private final Activity m_providedActivity;
+    private BluetoothEnabledListener m_bluetoothEnabledListener;
+    private LocationPermissionListener m_locationPermissionListener;
+    private LocationServicesListener m_locationServicesListener;
+    private List<BluetoothStartupHelperListener.EnablingStage> m_neededStages;
+
+    public BluetoothStartupHelper(BleManager bleManager)
+    {
+        m_neededStages = new ArrayList<>();
+        m_bleManager = bleManager;
+        m_providedActivity = null;
+    }
+
+    public BluetoothStartupHelper(Activity singletonActivity, BleManager bleManager)
+    {
+        m_neededStages = new ArrayList<>();
+        m_providedActivity = singletonActivity;
+        m_bleManager = bleManager;
+    }
+
+    private boolean isBleOff()
+    {
+        return m_bleManager.isBleSupported() && !m_bleManager.is(BleManagerState.ON);
+    }
+
+    private boolean isLocationPermissionEnabled()
+    {
+        return m_bleManager.isLocationEnabledForScanning_byRuntimePermissions();
+    }
+
+    private boolean isLocationServicesEnabled() {
+        return m_bleManager.isLocationEnabledForScanning_byOsServices();
+    }
+
+    private boolean needToEnable(BluetoothStartupHelperListener.EnablingStage stage)
+    {
+        return m_neededStages.contains(stage);
+    }
+
+    private void popStage()
+    {
+        m_neededStages.remove(0);
+    }
+
+    private  void setBleNeededStages()
+    {
+//        if(isBleOff())
+        {
+            m_neededStages.add(BluetoothStartupHelperListener.EnablingStage.ENABLE_BLUETOOTH);
+        }
+//        if(!isLocationPermissionEnabled())
+        {
+            m_neededStages.add(BluetoothStartupHelperListener.EnablingStage.REQUEST_LOCATION_PERMISSION);
+        }
+//        if(!isLocationServicesEnabled())
+        {
+            m_neededStages.add(BluetoothStartupHelperListener.EnablingStage.ENABLE_LOCATION_SERVICES);
+        }
+    }
+
+    public void enableEverything(BluetoothEnabledListener bluetoothListener, LocationPermissionListener locPermissionListener, LocationServicesListener locServicesListener)
+    {
+        enableEverything(m_providedActivity, bluetoothListener, locPermissionListener, locServicesListener);
+    }
+
+    public void enableEverything(Activity callingActivity, BluetoothEnabledListener bluetoothListener, LocationPermissionListener locPermissionListener, LocationServicesListener locServicesListener)
+    {
+        setBleNeededStages();
+        initListeners(bluetoothListener, locPermissionListener, locServicesListener);
+        enableNextRequirement();
+    }
+
+    public void enableNextRequirement()
+    {
+        enableNextRequirement(m_providedActivity);
+    }
+
+    public void enableNextRequirement(Activity callingActivity)
+    {
+        if(needToEnable(BluetoothStartupHelperListener.EnablingStage.ENABLE_BLUETOOTH))
+        {
+            popStage();
+            enableBluetooth(callingActivity);
+        }
+        else if(needToEnable(BluetoothStartupHelperListener.EnablingStage.REQUEST_LOCATION_PERMISSION))
+        {
+            popStage();
+            requestLocationPermission(callingActivity);
+        }
+        else if(needToEnable(BluetoothStartupHelperListener.EnablingStage.ENABLE_LOCATION_SERVICES))
+        {
+            popStage();
+            enableLocationServices(callingActivity);
+        }
+    }
+
+    private void initListeners(BluetoothEnabledListener bluetoothListener, LocationPermissionListener locationPermissionListener, LocationServicesListener locationServicesListener)
+    {
+        m_bluetoothEnabledListener = bluetoothListener;
+        m_locationPermissionListener = locationPermissionListener;
+        m_locationServicesListener = locationServicesListener;
+    }
+
+    private void enableBluetooth(Activity callingActivity)
+    {
+        enableBluetooth(callingActivity, m_bluetoothEnabledListener);
+    }
+
+    public void enableBluetooth(Activity callingActivity, BluetoothEnabledListener listener)
+    {
+        m_bluetoothEnabledListener = listener;
+        m_bleManager.turnOnWithIntent(callingActivity, BluetoothStartupHelperListener.EnablingStage.ENABLE_BLUETOOTH.getCode());
+    }
+
+    public void enableBluetoothResult(int requestCode, int resultCode)
+    {
+        if(requestCode == BluetoothStartupHelperListener.EnablingStage.ENABLE_BLUETOOTH.getCode())
+        {
+            if(resultCode == Activity.RESULT_OK)
+            {
+                m_bluetoothEnabledListener.bluetoothWasEnabled();
+            }
+            else
+            {
+                m_bluetoothEnabledListener.bluetoothStillDisabled();
+            }
+        }
+    }
+
+    public void requestLocationPermission(Activity callingActitity)
+    {
+        requestLocationPermission(callingActitity, m_locationPermissionListener);
+    }
+
+    public void requestLocationPermission(Activity callingActivity, LocationPermissionListener locationPermissionListener)
+    {
+        m_locationPermissionListener = locationPermissionListener;
+        m_bleManager.turnOnLocationWithIntent_forPermissions(callingActivity, BluetoothStartupHelperListener.EnablingStage.REQUEST_LOCATION_PERMISSION.getCode());
+    }
+
+    public void requestLocationPermissionResult(int requestCode, String[] permissions, int[] grantResult)
+    {
+        if(requestCode == BluetoothStartupHelperListener.EnablingStage.REQUEST_LOCATION_PERMISSION.getCode())
+        {
+            if(grantResult.length > 0 && grantResult[0] == PackageManager.PERMISSION_GRANTED)
+            {
+                m_locationPermissionListener.locationPermissionGranted();
+            }
+            else
+            {
+                m_locationPermissionListener.locationPermissionDenied();
+            }
+        }
+    }
+
+    public void enableLocationServices(Activity callingActivity)
+    {
+        enableLocationServices(callingActivity, m_locationServicesListener);
+    }
+
+    public void enableLocationServices(Activity callingActivity, LocationServicesListener locationServicesListener)
+    {
+        m_locationServicesListener = locationServicesListener;
+        m_bleManager.turnOnLocationWithIntent_forOsServices(callingActivity, BluetoothStartupHelperListener.EnablingStage.ENABLE_LOCATION_SERVICES.getCode());
+    }
+
+    public void enableLocationServicesResult(int requestCode, int resultCode)
+    {
+        if(requestCode == BluetoothStartupHelperListener.EnablingStage.ENABLE_LOCATION_SERVICES.getCode())
+        {
+            if(resultCode == Activity.RESULT_OK)
+            {
+                m_locationServicesListener.locationServicesEnabled();
+            }
+            else
+            {
+                m_locationServicesListener.locationServicesStillDisabled();
+            }
+        }
+    }
+
+
+
+
+}


### PR DESCRIPTION
Added BluetoothEnabler class which handles the new Marshmallow Location permissions and services requests. The BluetoothEnabler includes a default listener which allows the SweetBlue user to create an instance of the class by using the constructor which takes an Activity and that will handle all dialog popping internally. 