### PR TITLE
fixes #173

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,8 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/sweetblue.iml" filepath="$PROJECT_DIR$/sweetblue.iml" />
+      <module fileurl="file://$PROJECT_DIR$/sweetblue.iml" filepath="$PROJECT_DIR$/sweetblue.iml" />
+      <module fileurl="file://$PROJECT_DIR$/sweetblue.iml" filepath="$PROJECT_DIR$/sweetblue.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
@@ -217,7 +217,14 @@ class P_Task_Scan extends PA_Task_RequiresBleOn
 			}
 			else if( scanMode.isLollipopScanMode() )
 			{
-				execute_postLollipop();
+				if (Utils.isLollipop())
+				{
+					execute_postLollipop();
+				}
+				else
+				{
+					execute_preLollipop();
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Put in a check so that if LOW, MEDIUM, or HIGH_POWER options are set in BleManagerConfig, the ScanTask automatically falls back to preLollipop scanning when running on devices running an OS less than Lollipop.