### PR TITLE
Fixed foregrounding logic the enabler and made return objects more explicit

### DIFF
--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
@@ -575,11 +575,6 @@ public class BleManager
         mStateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, SCAN_READY_BLE, true);
     }
 
-    void setManagerClassicScanReady()
-    {
-        mStateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, SCAN_READY_CLASSIC, true);
-    }
-
     private void startScan_private(Interval scanTime, Interval pauseTime)
     {
         if (!isAny(SCANNING, SCAN_PAUSED, STARTING_SCAN))

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
@@ -570,9 +570,14 @@ public class BleManager
         mPostManager.postToUpdateThread(mUpdateRunnable);
     }
 
-    void setManagerReady()
+    void setManagerBLEScanReady()
     {
-        mStateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, SCAN_READY, true);
+        mStateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, SCAN_READY_BLE, true);
+    }
+
+    void setManagerClassicScanReady()
+    {
+        mStateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, SCAN_READY_CLASSIC, true);
     }
 
     private void startScan_private(Interval scanTime, Interval pauseTime)

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManagerState.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManagerState.java
@@ -62,14 +62,17 @@ public enum BleManagerState implements State
     IDLE,
 
     /**
-     * This is the state that {@link BleManager} is in when all required permissions and services (if any) are enabled for scanning to work.
+     * This is the state that {@link BleManager} is in when all required permissions and services (if any) are enabled for BLE scanning to work.
+     * This state also wraps the {@link BleManagerState#SCAN_READY_CLASSIC} so when the {@link BleManager} is {@link #SCAN_READY_BLE} it is also
+     * {@link #SCAN_READY_CLASSIC} even though it isn't explicitly in that state.
      */
-    SCAN_READY,
+    SCAN_READY_BLE,
 
     /**
-     * This is the state that the {@link BleManager} is in when it requires some permissions or services for scanning.
+     * * This is the state that {@link BleManager} is in when bluetooth is enabled but not all Marshmallow permission (when on a Marshmallow or above device)
+     * are granted so only classic scan can be used.
      */
-    SCAN_NOT_READY;
+    SCAN_READY_CLASSIC;
 
     private final int mNativeCode;
     private static BleManagerState[] sValues;

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManagerState.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManagerState.java
@@ -63,16 +63,9 @@ public enum BleManagerState implements State
 
     /**
      * This is the state that {@link BleManager} is in when all required permissions and services (if any) are enabled for BLE scanning to work.
-     * This state also wraps the {@link BleManagerState#SCAN_READY_CLASSIC} so when the {@link BleManager} is {@link #SCAN_READY_BLE} it is also
-     * {@link #SCAN_READY_CLASSIC} even though it isn't explicitly in that state.
      */
-    SCAN_READY_BLE,
+    SCAN_READY_BLE;
 
-    /**
-     * * This is the state that {@link BleManager} is in when bluetooth is enabled but not all Marshmallow permission (when on a Marshmallow or above device)
-     * are granted so only classic scan can be used.
-     */
-    SCAN_READY_CLASSIC;
 
     private final int mNativeCode;
     private static BleManagerState[] sValues;

--- a/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
@@ -213,10 +213,6 @@ public class BluetoothEnabler
                 {
                     bleManager.setManagerBLEScanReady();
                 }
-                else
-                {
-                    bleManager.setManagerClassicScanReady();
-                }
             }
         }
     }
@@ -433,7 +429,7 @@ public class BluetoothEnabler
 
         boolean isClassicScanningReady()
         {
-            return bleManager.isBleSupported() && bleManager.is(BleManagerState.ON) && bleManager.is(BleManagerState.SCAN_READY_CLASSIC);
+            return bleManager.is(BleManagerState.ON);
         }
 
         public enum Status

--- a/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
@@ -431,6 +431,11 @@ public class BluetoothEnabler
             return false;
         }
 
+        boolean isClassicScanningReady()
+        {
+            return bleManager.isBleSupported() && bleManager.is(BleManagerState.ON) && bleManager.is(BleManagerState.SCAN_READY_CLASSIC);
+        }
+
         public enum Status
         {
             ALREADY_ENABLED,

--- a/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BluetoothEnabler.java
@@ -201,7 +201,17 @@ public class BluetoothEnabler
     {
         if(mStateTracker.currentState == BluetoothEnablerState.DONE)
         {
-            bleManager.setManagerReady();
+            if(isStateSystemPropertyEnabled(BluetoothEnablerState.PROMPT_BLUETOOTH_PERMISSION))
+            {
+                if(isStateSystemPropertyEnabled(BluetoothEnablerState.PROMPT_LOCATION_PERMISSIONS) && isStateSystemPropertyEnabled(BluetoothEnablerState.PROMPT_LOCATION_SERVICES))
+                {
+                    bleManager.setManagerBLEScanReady();
+                }
+                else
+                {
+                    bleManager.setManagerClassicScanReady();
+                }
+            }
             return;
         }
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/DefaultBluetoothEnablerController.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/DefaultBluetoothEnablerController.java
@@ -30,7 +30,7 @@ public final class DefaultBluetoothEnablerController extends BluetoothEnablerCon
         }
         else if(event.isFor(BluetoothEnabler.BluetoothEnablerState.BLUETOOTH_PERMISSION_RESULT))
         {
-            if(event.didSucceed())
+            if(event.didSucceed() || event.status() == BluetoothEnabler.BluetoothEnablerStateEvent.Status.ALREADY_ENABLED)
             {
                 return Please.doNext();
             }
@@ -60,7 +60,7 @@ public final class DefaultBluetoothEnablerController extends BluetoothEnablerCon
         }
         else if(event.isFor(BluetoothEnabler.BluetoothEnablerState.LOCATION_PERMISSION_RESULT))
         {
-            if(event.didSucceed())
+            if(event.didSucceed() || event.status() == BluetoothEnabler.BluetoothEnablerStateEvent.Status.ALREADY_ENABLED)
             {
                 return Please.doNext();
             }
@@ -80,7 +80,7 @@ public final class DefaultBluetoothEnablerController extends BluetoothEnablerCon
         }
         else if(event.isFor(BluetoothEnabler.BluetoothEnablerState.LOCATION_SERVICES_RESULT))
         {
-            if(event.didSucceed())
+            if(event.didSucceed() || event.status() == BluetoothEnabler.BluetoothEnablerStateEvent.Status.ALREADY_ENABLED)
             {
                 return Please.doNext();
             }
@@ -90,7 +90,7 @@ public final class DefaultBluetoothEnablerController extends BluetoothEnablerCon
         else if(event.isFor(BluetoothEnabler.BluetoothEnablerState.DONE))
         {
             if (listener != null) {
-                listener.onFinished(event.isScanningReady());
+                listener.onFinished(event.isBleScanningReady());
             }
         }
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/DefaultBluetoothEnablerController.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/DefaultBluetoothEnablerController.java
@@ -3,6 +3,8 @@ package com.idevicesinc.sweetblue;
 import android.app.AlertDialog;
 import android.content.Context;
 
+import com.idevicesinc.sweetblue.listeners.EnablerDoneListener;
+
 public final class DefaultBluetoothEnablerController extends BluetoothEnablerController
 {
     protected static BluetoothEnablerConfig mConfig;
@@ -90,7 +92,16 @@ public final class DefaultBluetoothEnablerController extends BluetoothEnablerCon
         else if(event.isFor(BluetoothEnabler.BluetoothEnablerState.DONE))
         {
             if (listener != null) {
-                listener.onFinished(event.isBleScanningReady());
+                EnablerDoneListener.ScanTypeAvailable scanTypeAvailable = EnablerDoneListener.ScanTypeAvailable.NONE;
+                if(event.isBleScanningReady())
+                {
+                    scanTypeAvailable = EnablerDoneListener.ScanTypeAvailable.BLE;
+                }
+                else if(event.isClassicScanningReady())
+                {
+                    scanTypeAvailable = EnablerDoneListener.ScanTypeAvailable.CLASSIC;
+                }
+                listener.onFinished(scanTypeAvailable);
             }
         }
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
@@ -12,7 +12,7 @@ import com.idevicesinc.sweetblue.utils.Utils_String;
 import java.util.List;
 import static com.idevicesinc.sweetblue.BleManagerState.SCANNING;
 import static com.idevicesinc.sweetblue.BleManagerState.SCAN_PAUSED;
-import static com.idevicesinc.sweetblue.BleManagerState.SCAN_READY;
+import static com.idevicesinc.sweetblue.BleManagerState.SCAN_READY_BLE;
 import static com.idevicesinc.sweetblue.BleManagerState.STARTING_SCAN;
 
 
@@ -68,7 +68,7 @@ final class P_ScanManager
                 mCurrentApi = BleScanAPI.CLASSIC;
                 return mManager.getNativeAdapter().startDiscovery();
             case POST_LOLLIPOP:
-                if (mManager.is(SCAN_READY))
+                if (mManager.is(SCAN_READY_BLE))
                 {
                     if (Utils.isLollipop())
                     {

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
@@ -32,7 +32,7 @@ public final class P_Task_Scan extends P_Task_RequiresBleOn
 
     @Override public final void execute()
     {
-        if (getManager().is(BleManagerState.SCAN_READY) || getManager().mConfig.revertToClassicDiscoveryIfNeeded)
+        if (getManager().is(BleManagerState.SCAN_READY_BLE) || getManager().mConfig.revertToClassicDiscoveryIfNeeded)
         {
             if (!getManager().mScanManager.startScan())
             {

--- a/app/src/main/java/com/idevicesinc/sweetblue/listeners/EnablerDoneListener.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/listeners/EnablerDoneListener.java
@@ -2,5 +2,5 @@ package com.idevicesinc.sweetblue.listeners;
 
 public interface EnablerDoneListener
 {
-    void onFinished(boolean isScanningReady);
+    void onFinished(boolean isBleScanningReady);
 }

--- a/app/src/main/java/com/idevicesinc/sweetblue/listeners/EnablerDoneListener.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/listeners/EnablerDoneListener.java
@@ -2,5 +2,12 @@ package com.idevicesinc.sweetblue.listeners;
 
 public interface EnablerDoneListener
 {
-    void onFinished(boolean isBleScanningReady);
+    enum ScanTypeAvailable
+    {
+        NONE,
+        BLE,
+        CLASSIC
+    }
+
+    void onFinished(ScanTypeAvailable scanTypeAvailable);
 }


### PR DESCRIPTION
-Fixed the issue where the enabler would return control back to the caller when the bluetooth permission dialog was popped but not clicked on.
-Made the scanning state more explicit (classic or ble) for the BleManager
-Made the return value of the EnablerDoneListener more explicit to know exactly which scan method(s) were enabled when the enabler finished