### PR TITLE
SWEET-304 and SWEET-305

### DIFF
--- a/app/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
@@ -6623,27 +6623,27 @@ public final class BleDevice extends BleNode
 
         if (listener_nullable != null)
         {
-            postEvent(listener_nullable, event);
+            postEventAsCallback(listener_nullable, event);
         }
 
         if (m_defaultReadWriteListener != null)
         {
-            postEvent(m_defaultReadWriteListener, event);
+            postEventAsCallback(m_defaultReadWriteListener, event);
         }
 
         if (getManager() != null && getManager().m_defaultReadWriteListener != null)
         {
-            postEvent(getManager().m_defaultReadWriteListener, event);
+            postEventAsCallback(getManager().m_defaultReadWriteListener, event);
         }
 
         if (m_defaultNotificationListener != null && (event.type().isNotification() || event.type() == Type.DISABLING_NOTIFICATION || event.type() == Type.ENABLING_NOTIFICATION))
         {
-            postEvent(m_defaultNotificationListener, fromReadWriteEvent(event));
+            postEventAsCallback(m_defaultNotificationListener, fromReadWriteEvent(event));
         }
 
         if (getManager() != null && getManager().m_defaultNotificationListener != null)
         {
-            postEvent(getManager().m_defaultNotificationListener, fromReadWriteEvent(event));
+            postEventAsCallback(getManager().m_defaultNotificationListener, fromReadWriteEvent(event));
         }
 
         m_txnMngr.onReadWriteResultCallbacksCalled();
@@ -6832,13 +6832,16 @@ public final class BleDevice extends BleNode
     }
     // static String NULL_MAC = "DE:AD:BE:EF:BA:BE";
 
-    private void postEvent(final GenericListener_Void listener, final Event event)
+    void postEventAsCallback(final GenericListener_Void listener, final Event event)
     {
         getManager().getPostManager().postCallback(new Runnable()
         {
             @Override public void run()
             {
-                listener.onEvent(event);
+                if (listener != null)
+                {
+                    listener.onEvent(event);
+                }
             }
         });
     }

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
@@ -46,6 +46,7 @@ import com.idevicesinc.sweetblue.utils.EpochTime;
 import com.idevicesinc.sweetblue.utils.Event;
 import com.idevicesinc.sweetblue.utils.ForEach_Breakable;
 import com.idevicesinc.sweetblue.utils.ForEach_Void;
+import com.idevicesinc.sweetblue.utils.GenericListener_Void;
 import com.idevicesinc.sweetblue.utils.HistoricalData;
 import com.idevicesinc.sweetblue.utils.Interval;
 import com.idevicesinc.sweetblue.utils.Percent;
@@ -148,7 +149,7 @@ public final class BleManager
 	 * overloads of {@link BleManager#startScan()} and {@link BleManager#startPeriodicScan(Interval, Interval)}.
 	 */
 	@com.idevicesinc.sweetblue.annotations.Lambda
-	public static interface DiscoveryListener
+	public static interface DiscoveryListener extends GenericListener_Void<DiscoveryEvent>
 	{
 		/**
 		 * Enumerates changes in the "discovered" state of a device.
@@ -3076,6 +3077,20 @@ public final class BleManager
 		onDiscovered_wrapItUp(device, device.layerManager().getDeviceLayer(), newlyDiscovered, scanRecord_nullable, rssi, BleDeviceOrigin.FROM_DISCOVERY, /*scanEvent=*/null);
 	}
 
+	void postEvent(final GenericListener_Void listener, final Event event)
+	{
+		m_postManager.postCallback(new Runnable()
+		{
+			@Override public void run()
+			{
+				if (listener != null)
+				{
+					listener.onEvent(event);
+				}
+			}
+		});
+	}
+
     private void onDiscovered_wrapItUp(final BleDevice device, final P_NativeDeviceLayer device_native, final boolean newlyDiscovered, final byte[] scanRecord_nullable, final int rssi, final BleDeviceOrigin origin, ScanFilter.ScanEvent scanEvent_nullable)
     {
     	if( newlyDiscovered )
@@ -3084,14 +3099,8 @@ public final class BleManager
 
     		if( m_discoveryListener != null )
     		{
-				m_postManager.postCallback(new Runnable()
-				{
-					@Override public void run()
-					{
-						DiscoveryEvent event = new DiscoveryEvent(device, LifeCycle.DISCOVERED);
-						m_discoveryListener.onEvent(event);
-					}
-				});
+				final DiscoveryEvent event = new DiscoveryEvent(device, LifeCycle.DISCOVERED);
+				postEvent(m_discoveryListener, event);
     		}
     	}
     	else
@@ -3100,14 +3109,8 @@ public final class BleManager
 
     		if( m_discoveryListener != null )
     		{
-				m_postManager.postCallback(new Runnable()
-				{
-					@Override public void run()
-					{
-						DiscoveryEvent event = new DiscoveryEvent(device, LifeCycle.REDISCOVERED);
-						m_discoveryListener.onEvent(event);
-					}
-				});
+				final DiscoveryEvent event = new DiscoveryEvent(device, LifeCycle.REDISCOVERED);
+				postEvent(m_discoveryListener, event);
     		}
     	}
     }

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleNode.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleNode.java
@@ -18,6 +18,7 @@ import com.idevicesinc.sweetblue.utils.Event;
 import com.idevicesinc.sweetblue.utils.ForEach_Breakable;
 import com.idevicesinc.sweetblue.utils.ForEach_Void;
 import com.idevicesinc.sweetblue.utils.FutureData;
+import com.idevicesinc.sweetblue.utils.GenericListener_Void;
 import com.idevicesinc.sweetblue.utils.HistoricalData;
 import com.idevicesinc.sweetblue.utils.HistoricalDataColumn;
 import com.idevicesinc.sweetblue.utils.HistoricalDataQuery;
@@ -231,7 +232,7 @@ public abstract class BleNode implements UsesCustomNull
 	 * and {@link BleManager#setListener_HistoricalDataLoad(BleNode.HistoricalDataLoadListener)}.
 	 */
 	@com.idevicesinc.sweetblue.annotations.Lambda
-	public static interface HistoricalDataLoadListener
+	public static interface HistoricalDataLoadListener extends GenericListener_Void<HistoricalDataLoadListener.HistoricalDataLoadEvent>
 	{
 		/**
 		 * Enumerates the status codes for operations kicked off from {@link BleDevice#loadHistoricalData()} (or overloads).
@@ -356,7 +357,7 @@ public abstract class BleNode implements UsesCustomNull
 	 */
 	@com.idevicesinc.sweetblue.annotations.Alpha
 	@com.idevicesinc.sweetblue.annotations.Lambda
-	public static interface HistoricalDataQueryListener
+	public static interface HistoricalDataQueryListener extends GenericListener_Void<HistoricalDataQueryListener.HistoricalDataQueryEvent>
 	{
 		/**
 		 * Enumerates the status codes for operations kicked off from {@link BleDevice#select()}.
@@ -893,13 +894,7 @@ public abstract class BleNode implements UsesCustomNull
 				{
 					final BleDevice.HistoricalDataQueryListener.HistoricalDataQueryEvent e = queryHistoricalData(query);
 
-					getManager().getPostManager().postCallback(new Runnable()
-					{
-						@Override public void run()
-						{
-							listener.onEvent(e);
-						}
-					});
+					getManager().postEvent(listener, e);
 				}
 			});
 		}

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleServer.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleServer.java
@@ -2198,7 +2198,10 @@ public final class BleServer extends BleNode
 			{
 				@Override public void run()
 				{
-					listener_specific_nullable.onEvent(e);
+					if (listener_specific_nullable != null)
+					{
+						listener_specific_nullable.onEvent(e);
+					}
 				}
 			});
 		}
@@ -2209,7 +2212,10 @@ public final class BleServer extends BleNode
 			{
 				@Override public void run()
 				{
-					m_outgoingListener_default.onEvent(e);
+					if (m_outgoingListener_default != null)
+					{
+						m_outgoingListener_default.onEvent(e);
+					}
 				}
 			});
 		}
@@ -2220,7 +2226,10 @@ public final class BleServer extends BleNode
 			{
 				@Override public void run()
 				{
-					getManager().m_defaultServerOutgoingListener.onEvent(e);
+					if (getManager().m_defaultServerOutgoingListener != null)
+					{
+						getManager().m_defaultServerOutgoingListener.onEvent(e);
+					}
 				}
 			});
 		}

--- a/app/src/main/java/com/idevicesinc/sweetblue/DeviceStateListener.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/DeviceStateListener.java
@@ -1,6 +1,8 @@
 package com.idevicesinc.sweetblue;
 
 
+import com.idevicesinc.sweetblue.utils.GenericListener_Void;
+
 /**
  * Provide an implementation to {@link BleDevice#setListener_State(DeviceStateListener)} and/or
  * {@link BleManager#setListener_DeviceState(DeviceStateListener)} to receive state change events.
@@ -9,7 +11,7 @@ package com.idevicesinc.sweetblue;
  * @see BleDevice#setListener_State(DeviceStateListener)
  */
 @com.idevicesinc.sweetblue.annotations.Lambda
-public interface DeviceStateListener
+public interface DeviceStateListener extends GenericListener_Void<BleDevice.StateListener.StateEvent>
 {
 
     // TODO - Uncomment the below for version 3 (or better yet, copy it from BleDevice in case of changes)

--- a/app/src/main/java/com/idevicesinc/sweetblue/ManagerStateListener.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/ManagerStateListener.java
@@ -1,12 +1,14 @@
 package com.idevicesinc.sweetblue;
 
 
+import com.idevicesinc.sweetblue.utils.GenericListener_Void;
+
 /**
  * Provide an implementation to {@link BleManager#setListener_State(ManagerStateListener)} to receive callbacks
  * when the {@link BleManager} undergoes a {@link BleManagerState} change.
  */
 @com.idevicesinc.sweetblue.annotations.Lambda
-public interface ManagerStateListener
+public interface ManagerStateListener extends GenericListener_Void<BleManager.StateListener.StateEvent>
 {
 
     // TODO - Uncomment the below for version 3 (or better yet, copy it from BleManager in case of changes/bug fixes)

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_AndroidBluetoothManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_AndroidBluetoothManager.java
@@ -1,7 +1,6 @@
 package com.idevicesinc.sweetblue;
 
 
-
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
@@ -9,15 +8,19 @@ import android.bluetooth.BluetoothGattServer;
 import android.bluetooth.BluetoothManager;
 import android.bluetooth.le.BluetoothLeAdvertiser;
 import android.content.Context;
+import android.os.DeadObjectException;
+
 import com.idevicesinc.sweetblue.compat.L_Util;
 import com.idevicesinc.sweetblue.compat.M_Util;
 import com.idevicesinc.sweetblue.utils.Interval;
+import com.idevicesinc.sweetblue.utils.Pointer;
 import com.idevicesinc.sweetblue.utils.Utils;
+
 import java.lang.reflect.Method;
 import java.util.Set;
+
 import static com.idevicesinc.sweetblue.BleManagerState.OFF;
 import static com.idevicesinc.sweetblue.BleManagerState.ON;
-
 
 
 public final class P_AndroidBluetoothManager implements P_NativeManagerLayer
@@ -29,8 +32,6 @@ public final class P_AndroidBluetoothManager implements P_NativeManagerLayer
     private static Method m_getLeState_marshmallow;
     private static Integer m_refState;
     private static Integer m_state;
-
-
 
 
     public void setBleManager(BleManager mgr)
@@ -108,9 +109,18 @@ public final class P_AndroidBluetoothManager implements P_NativeManagerLayer
             {
                 return m_state;
             }
+            else
+            {
+                m_refState = BleStatuses.STATE_OFF;
+            }
             return m_refState;
         } catch (Exception e)
         {
+            if (e instanceof DeadObjectException)
+            {
+                BleManager.UhOhListener.UhOh uhoh = BleManager.UhOhListener.UhOh.DEAD_OBJECT_EXCEPTION;
+                m_bleManager.uhOh(uhoh);
+            }
             return m_adaptor.getState();
         }
     }
@@ -151,12 +161,14 @@ public final class P_AndroidBluetoothManager implements P_NativeManagerLayer
     }
 
     @Override
-    public BluetoothAdapter getNativeAdaptor() {
+    public BluetoothAdapter getNativeAdaptor()
+    {
         return m_adaptor;
     }
 
     @Override
-    public BluetoothManager getNativeManager() {
+    public BluetoothManager getNativeManager()
+    {
         return m_manager;
     }
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
@@ -2,6 +2,7 @@ package com.idevicesinc.sweetblue;
 
 import static com.idevicesinc.sweetblue.BleManagerState.IDLE;
 import static com.idevicesinc.sweetblue.BleManagerState.OFF;
+import static com.idevicesinc.sweetblue.BleManagerState.ON;
 import static com.idevicesinc.sweetblue.BleManagerState.SCANNING;
 import static com.idevicesinc.sweetblue.BleManagerState.STARTING_SCAN;
 
@@ -192,7 +193,10 @@ final class P_BleManager_Listeners
         // If this was discovered via the hack to show the bond popup, then do not propogate this
         // any further, as this scan is JUST to get the dialog to pop up (rather than show in the notification area)
         P_Task_BondPopupHack hack = m_mngr.getTaskQueue().getCurrent(P_Task_BondPopupHack.class, m_mngr);
-        if (hack == null)
+
+        // Only pipe discovery event if the scan task is running, and the manager says we're doing a classic scan
+        P_Task_Scan scan = m_mngr.getTaskQueue().getCurrent(P_Task_Scan.class, m_mngr);
+        if (hack == null && scan != null && m_mngr.m_config.scanApi == BleScanApi.CLASSIC)
         {
             final BluetoothDevice device_native = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
             final int rssi = intent.getShortExtra(BluetoothDevice.EXTRA_RSSI, Short.MIN_VALUE);

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_BleStateTracker.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_BleStateTracker.java
@@ -24,19 +24,8 @@ final class P_BleStateTracker extends PA_StateTracker
 	{
 		if( m_stateListener != null )
 		{
-			m_mngr.getPostManager().postCallback(new Runnable()
-			{
-				@Override public void run()
-				{
-					//--- RB > Add an additional null guard here. It's possible that in the time it took for this Runnable to execute,
-					//---		the listener got nulled out.
-					if (m_stateListener != null)
-					{
-						final StateEvent event = new StateEvent(m_mngr, oldStateBits, newStateBits, intentMask);
-						m_stateListener.onEvent(event);
-					}
-				}
-			});
+			final StateEvent event = new StateEvent(m_mngr, oldStateBits, newStateBits, intentMask);
+			m_mngr.postEvent(m_stateListener, event);
 		}
 	}
 	

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_DeviceStateTracker.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_DeviceStateTracker.java
@@ -47,27 +47,14 @@ final class P_DeviceStateTracker extends PA_StateTracker
 
 		if( m_stateListener != null )
 		{
-			m_device.getManager().getPostManager().postCallback(new Runnable()
-			{
-				@Override public void run()
-				{
-					StateEvent event = new StateEvent(m_device, oldStateBits, newStateBits, intentMask, gattStatus);
-					m_stateListener.onEvent(event);
-				}
-			});
+			final StateEvent event = new StateEvent(m_device, oldStateBits, newStateBits, intentMask, gattStatus);
+			m_device.postEventAsCallback(m_stateListener, event);
 		}
 		
 		if( !m_forShortTermReconnect && m_device.getManager().m_defaultDeviceStateListener != null )
 		{
-			m_device.getManager().getPostManager().postCallback(new Runnable()
-			{
-				@Override public void run()
-				{
-					StateEvent event = new StateEvent(m_device, oldStateBits, newStateBits, intentMask, gattStatus);
-					m_device.getManager().m_defaultDeviceStateListener.onEvent(event);
-				}
-			});
-
+			final StateEvent event = new StateEvent(m_device, oldStateBits, newStateBits, intentMask, gattStatus);
+			m_device.postEventAsCallback(m_device.getManager().m_defaultDeviceStateListener, event);
 		}
 
 		final BleDeviceConfig.BondFilter bondFilter = BleDeviceConfig.filter(m_device.conf_device().bondFilter, m_device.conf_mngr().bondFilter);

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_HistoricalDataManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_HistoricalDataManager.java
@@ -536,14 +536,7 @@ final class P_HistoricalDataManager
 		final BleDevice.HistoricalDataLoadListener.HistoricalDataLoadEvent event = event_nullable != null ? event_nullable : new BleDevice.HistoricalDataLoadListener.HistoricalDataLoadEvent(m_endPoint, m_macAddress, uuid, range, status);
 		if( listener_nullable != null )
 		{
-			m_endPoint.getManager().getPostManager().postCallback(new Runnable()
-			{
-				@Override public void run()
-				{
-
-					listener_nullable.onEvent(event);
-				}
-			});
+			m_endPoint.getManager().postEvent(listener_nullable, event);
 		}
 
 		return event;

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_NativeDeviceWrapper.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_NativeDeviceWrapper.java
@@ -9,6 +9,8 @@ import com.idevicesinc.sweetblue.utils.Utils_String;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.idevicesinc.sweetblue.BleManagerState.ON;
+
 
 final class P_NativeDeviceWrapper
 {
@@ -20,6 +22,8 @@ final class P_NativeDeviceWrapper
 	private String m_name_normalized;
 	private String m_name_debug;
 	private String m_name_override;
+
+	private int m_bondState_cached = BluetoothDevice.BOND_NONE;
 	
 	//--- DRK > We have to track connection state ourselves because using
 	//---		BluetoothManager.getConnectionState() is slightly out of date
@@ -220,7 +224,18 @@ final class P_NativeDeviceWrapper
 	
 	public int getNativeBondState()
 	{
-		final int bondState_native = m_device_native != null ? m_device_native.getBondState() : BluetoothDevice.BOND_NONE;
+		int bondState_native;
+		//--- > RB  If Bluetooth is not on, then we can't get the current bond state. This is here to catch the times when the system
+		// 			decides to turn BT off/on. This prevents spamming the logs with a bunch of messages about not being able to get the
+		// 			bond state
+		if (m_device_native != null && getManager().is(ON))
+		{
+			bondState_native = m_device_native.getBondState();
+			m_bondState_cached = bondState_native;
+		}
+		else
+		{
+			bondState_native = m_bondState_cached;		}
 		
 		return bondState_native;
 	}
@@ -260,7 +275,16 @@ final class P_NativeDeviceWrapper
 	
 	public int getNativeConnectionState()
 	{
-		return m_device.layerManager().getManagerLayer().getConnectionState(m_device_native, BluetoothGatt.GATT_SERVER);
+		//--- > RB If BT has been turned off quickly (for instance, there are many devices connected, then you go into BT settings and run a scan), then
+		// 			we obviously won't be able to get a state. We return DISCONNECTED here for obvious reasons.
+		if (getManager().m_config.nativeManagerLayer.isBluetoothEnabled())
+		{
+			return m_device.layerManager().getManagerLayer().getConnectionState(m_device_native, BluetoothGatt.GATT_SERVER);
+		}
+		else
+		{
+			return BluetoothGatt.STATE_DISCONNECTED;
+		}
 	}
 	
 	public int getConnectionState()

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
@@ -4,8 +4,11 @@ package com.idevicesinc.sweetblue;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import com.idevicesinc.sweetblue.compat.L_Util;
+import com.idevicesinc.sweetblue.utils.BleScanInfo;
 import com.idevicesinc.sweetblue.utils.Interval;
+import com.idevicesinc.sweetblue.utils.Pointer;
 import com.idevicesinc.sweetblue.utils.Utils;
+import com.idevicesinc.sweetblue.utils.Utils_ScanRecord;
 import com.idevicesinc.sweetblue.utils.Utils_String;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -178,15 +181,25 @@ final class P_ScanManager
         stopScan_private(false);
     }
 
-    final synchronized void postScanResult(final BluetoothDevice device, final int rssi, final byte[] scanRecord)
+    final void postScanResult(final BluetoothDevice device, final int rssi, final byte[] scanRecord)
     {
-        m_manager.getPostManager().postToUpdateThread(new Runnable()
+        final Pointer<String> name = new Pointer<>(device.getName());
+        m_manager.getPostManager().runOrPostToUpdateThread(new Runnable()
         {
             @Override public void run()
             {
-
                 final P_NativeDeviceLayer layer = m_manager.m_config.newDeviceLayer(BleDevice.NULL);
                 layer.setNativeDevice(device);
+
+                //--- > RB This is here because it has been observed that on Samsung devices, the BluetoothDevice getName() method can return a different name
+                //          here, versus before posting this Runnable. This hack prevents bad discoveries from getting piped up to app-level.
+
+                final String name2 = device.getName();
+
+                if (name.value != null && name2 != null && !name.value.equals(name2))
+                {
+                    return;
+                }
 
                 m_manager.getCrashResolver().notifyScannedDevice(layer, m_preLollipopScanCallback);
 
@@ -195,9 +208,9 @@ final class P_ScanManager
         });
     }
 
-    final synchronized void postBatchScanResult(final List<L_Util.ScanResult> devices)
+    final void postBatchScanResult(final List<L_Util.ScanResult> devices)
     {
-        m_manager.getPostManager().postToUpdateThread(new Runnable()
+        m_manager.getPostManager().runOrPostToUpdateThread(new Runnable()
         {
             @Override public void run()
             {

--- a/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
+++ b/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
@@ -106,9 +106,10 @@ public class MainActivity extends Activity
 
         BleManagerConfig config = new BleManagerConfig();
         config.loggingEnabled = true;
-        config.scanApi = BleScanApi.PRE_LOLLIPOP;
+        config.scanApi = BleScanApi.POST_LOLLIPOP;
         config.useGattRefresh = true;
         config.runOnMainThread = false;
+
 
         mLogger = new DebugLogger(100);
         config.logger = mLogger;
@@ -246,6 +247,7 @@ public class MainActivity extends Activity
         @Override public View getView(int position, View convertView, ViewGroup parent)
         {
             ViewHolder v;
+            final BleDevice device = mDevices.get(position);
             if (convertView == null)
             {
                 convertView = View.inflate(getContext(), R.layout.scan_listitem_layout, null);
@@ -258,7 +260,7 @@ public class MainActivity extends Activity
             {
                 v = (ViewHolder) convertView.getTag();
             }
-            v.name.setText(Utils_String.concatStrings(mDevices.get(position).toString(), "\nNative Name: ", mDevices.get(position).getName_native()));
+            v.name.setText(Utils_String.concatStrings(device.toString(), "\nNative Name: ", device.getName_native()));
             //v.rssi.setText(String.valueOf(mDevices.get(position).getRssi()));
             return convertView;
         }

--- a/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
+++ b/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
@@ -106,10 +106,17 @@ public class MainActivity extends Activity
 
         BleManagerConfig config = new BleManagerConfig();
         config.loggingEnabled = true;
-        config.scanApi = BleScanApi.POST_LOLLIPOP;
+        config.scanApi = BleScanApi.PRE_LOLLIPOP;
         config.useGattRefresh = true;
+        config.saveNameChangesToDisk = false;
         config.runOnMainThread = false;
-
+        config.defaultScanFilter = new BleManagerConfig.ScanFilter()
+        {
+            @Override public Please onEvent(ScanEvent e)
+            {
+                return Please.acknowledgeIf(e.name_normalized().contains("tag") || e.name_normalized().contains("pavlok"));
+            }
+        };
 
         mLogger = new DebugLogger(100);
         config.logger = mLogger;


### PR DESCRIPTION
Post callbacks to common method which checks if the listener is null before trying to call the onEvent method. Added check for samsung devices where if the name doesn't match, we ignore it, to prevent duplicate devices, which aren't actually duplicates (the name would match, but nothing else)