### PR TITLE
update blestate to act on native broadcasts, unless actively checking…

### DIFF
--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
@@ -345,7 +345,7 @@ public final class BleManager
 	 * @see BleManager.UhOhListener.UhOh
 	 */
 	@com.idevicesinc.sweetblue.annotations.Lambda
-	public static interface UhOhListener
+	public static interface UhOhListener extends com.idevicesinc.sweetblue.utils.GenericListener_Void<UhOhListener.UhOhEvent>
 	{
 		/**
 		 * An UhOh is a warning about an exceptional (in the bad sense) and unfixable problem with the underlying stack that
@@ -523,8 +523,8 @@ public final class BleManager
 		/**
 		 * Struct passed to {@link BleManager.UhOhListener#onEvent(BleManager.UhOhListener.UhOhEvent)}.
 		 */
-		@Immutable
-		public static class UhOhEvent extends Event
+		@com.idevicesinc.sweetblue.annotations.Immutable
+		public static class UhOhEvent extends com.idevicesinc.sweetblue.utils.Event
 		{
 			/**
 			 * The manager associated with the {@link BleManager.UhOhListener.UhOhEvent}
@@ -740,6 +740,8 @@ public final class BleManager
 //		}
 	}
 
+	private final static long UPDATE_LOOP_WARNING_DELAY = 10000;
+
 	private final Context m_context;
 	private UpdateRunnable m_updateRunnable;
 	private final P_ScanFilterManager m_filterMngr;
@@ -777,6 +779,7 @@ public final class BleManager
 	private boolean m_isForegrounded = false;
 	private boolean m_ready = false;
 	private boolean m_unitTestCheckDone = false;
+    private long m_lastUpdateLoopWarning = 0;
 
     BleServer.StateListener m_defaultServerStateListener;
 	BleServer.OutgoingListener m_defaultServerOutgoingListener;
@@ -3216,8 +3219,9 @@ public final class BleManager
 			m_config.updateLoopCallback.onUpdate(timeStep_seconds);
 		}
 
-		if (!is(IDLE) && m_config.autoUpdateRate.millis() < (System.currentTimeMillis() - m_currentTick))
+		if (!is(IDLE) && m_config.autoUpdateRate.millis() < (System.currentTimeMillis() - m_currentTick) && (m_lastUpdateLoopWarning + UPDATE_LOOP_WARNING_DELAY <= m_currentTick))
 		{
+            m_lastUpdateLoopWarning = m_currentTick;
 			getLogger().w("BleManager", String.format("Update loop took longer to run than the current interval of %dms", m_config.autoUpdateRate.millis()));
 		}
 	}

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
@@ -231,32 +231,39 @@ final class P_BleManager_Listeners
 
         if (Utils.isMarshmallow())
         {
+            //--- > RB Commenting all this logic out. It's my opinion that we should never ignore native callbacks. Granted, we also poll the native
+            //---       state on devices running Marshmallow or higher, but there are times when polling is insufficient (we could potentially get several
+            //---       broadcasts between update ticks). So we'll just check if we're already checking the state, if not, we filter this broadcast through
+            //---       to the system.
             // If in the IDLE state, we will pass the state change through as if pre 6.0, and bump out of the IDLE state
             // to catch any other changes that may happen in polling.
-            if (m_mngr.is(IDLE))
-            {
+//            if (m_mngr.is(IDLE))
+//            {
                 // If we're checking the state in the update method, don't bother posting this here. We'll fall out of IDLE state, so any further changes
                 // will be caught soon in polling.
                 if (!m_checkingState)
                 {
                     onNativeBleStateChange(previousNativeState, newNativeState);
                 }
-                m_mngr.m_stateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, IDLE, false);
-                m_mngr.checkIdleStatus();
-            }
-            else if (previousNativeState == BleStatuses.STATE_ON && newNativeState == BleStatuses.STATE_TURNING_OFF)
-            {
-                if (m_nativeState == BleStatuses.STATE_ON)
-                {
-                    m_nativeState = BleStatuses.STATE_TURNING_OFF;
+//                m_mngr.m_stateTracker.update(E_Intent.INTENTIONAL, BleStatuses.GATT_STATUS_NOT_APPLICABLE, IDLE, false);
+//                m_mngr.checkIdleStatus();
+//            }
 
-                    //--- DRK > We allow this code path in this particular case in marshmallow because STATE_TURNING_OFF is only active
-                    //---		for a very short time, so polling might miss it. If polling detects it before this, fine, because we
-                    //---		early-out above and never call this method. If afterwards, it skips it because m_nativeState is identical
-                    //---		to what's reported from the native stack.
-                    onNativeBleStateChange(previousNativeState, newNativeState);
-                }
-            }
+            //--- > RB The below is commented out because above we are handling all states from the native callback, unless polling is currently checking
+            //---       the state.
+//            /*else*/ if (previousNativeState == BleStatuses.STATE_ON && newNativeState == BleStatuses.STATE_TURNING_OFF)
+//            {
+//                if (m_nativeState == BleStatuses.STATE_ON)
+//                {
+//                    m_nativeState = BleStatuses.STATE_TURNING_OFF;
+//
+//                    //--- DRK > We allow this code path in this particular case in marshmallow because STATE_TURNING_OFF is only active
+//                    //---		for a very short time, so polling might miss it. If polling detects it before this, fine, because we
+//                    //---		early-out above and never call this method. If afterwards, it skips it because m_nativeState is identical
+//                    //---		to what's reported from the native stack.
+//                    onNativeBleStateChange(previousNativeState, newNativeState);
+//                }
+//            }
         }
         else
         {

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_DeviceManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_DeviceManager.java
@@ -471,6 +471,7 @@ final class P_DeviceManager
             if (device_ith.is(BleDeviceState.CONNECTED))
             {
                 device_ith.m_nativeWrapper.updateNativeConnectionState(device_ith.getNativeGatt());
+                device_ith.onNativeDisconnect(false, BleStatuses.GATT_STATUS_NOT_APPLICABLE, false, true);
             }
 
             final boolean retainDeviceWhenBleTurnsOff = BleDeviceConfig.bool(device_ith.conf_device().retainDeviceWhenBleTurnsOff, device_ith.conf_mngr().retainDeviceWhenBleTurnsOff);

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_UhOhThrottler.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_UhOhThrottler.java
@@ -57,7 +57,7 @@ final class P_UhOhThrottler
 		{
 			m_lastTimesCalled.put(reason, m_timeTracker);
 			UhOhEvent event = new UhOhEvent(m_mngr, reason);
-			m_uhOhListener.onEvent(event);
+			m_mngr.postEvent(m_uhOhListener, event);
 		}
 	}
 	

--- a/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
+++ b/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
@@ -107,9 +107,9 @@ public class MainActivity extends Activity
         BleManagerConfig config = new BleManagerConfig();
         config.loggingEnabled = true;
         config.scanApi = BleScanApi.PRE_LOLLIPOP;
-        config.useGattRefresh = true;
         config.saveNameChangesToDisk = false;
         config.runOnMainThread = false;
+        config.uhOhCallbackThrottle = Interval.secs(60.0);
         config.defaultScanFilter = new BleManagerConfig.ScanFilter()
         {
             @Override public Please onEvent(ScanEvent e)
@@ -118,10 +118,16 @@ public class MainActivity extends Activity
             }
         };
 
-        mLogger = new DebugLogger(100);
-        config.logger = mLogger;
-
         mgr = BleManager.get(this, config);
+
+        mgr.setListener_UhOh(new BleManager.UhOhListener()
+        {
+            @Override public void onEvent(UhOhEvent e)
+            {
+                Log.e("UhOhs", "Got " + e.uhOh() + " with remedy " + e.remedy());
+            }
+        });
+
         mgr.setListener_State(new BleManager.StateListener()
         {
             @Override public void onEvent(StateEvent event)

--- a/tester/src/test/java/com/idevicesinc/sweetblue/ConnectTest.java
+++ b/tester/src/test/java/com/idevicesinc/sweetblue/ConnectTest.java
@@ -692,8 +692,8 @@ public class ConnectTest extends BaseBleUnitTest
                             if (e.didEnter(BleDeviceState.CONNECTING))
                             {
                                 hasConnected = true;
-                                m_device.disconnect();
                                 ((DisconnectGattLayer) m_device.layerManager().getGattLayer()).disconnectCalled = true;
+                                m_device.disconnect();
                             }
                             else if (hasConnected && e.didEnter(BleDeviceState.DISCONNECTED))
                             {


### PR DESCRIPTION
… in the poll, call onNativeDisconnect when BLE gets turned off (goes right from ON -> OFF) to make sure connected devices get reconnected when BLE comes back up