### PR TITLE
Corrected scan task to account for boost scan time.

### DIFF
--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManager.java
@@ -3375,7 +3375,9 @@ public final class BleManager
 			double timeStep = ((double) currentTime - m_lastAutoUpdateTime)/1000.0;
 
 			timeStep = timeStep <= 0.0 ? .00001 : timeStep;
-			timeStep = timeStep > 1.0 ? 1.0 : timeStep;
+			//--- RB > Not sure why this was put here. If the tick is over a second, we still want to know that, otherwise tasks will end up running longer
+			// 			than expected.
+//			timeStep = timeStep > 1.0 ? 1.0 : timeStep;
 
 			update(timeStep, currentTime);
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleManagerConfig.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleManagerConfig.java
@@ -348,7 +348,7 @@ public class BleManagerConfig extends BleDeviceConfig
 	 */
 	@com.idevicesinc.sweetblue.annotations.Advanced
 	@Nullable(Prevalence.RARE)
-	public Interval scanReportDelay							= Interval.secs(DEFAULT_SCAN_REPORT_DELAY);
+	public Interval scanReportDelay							= Interval.DISABLED; // Interval.secs(DEFAULT_SCAN_REPORT_DELAY);
 
 	/**
 	 * Default is <code>null</code>, meaning no filtering - all discovered devices will

--- a/app/src/main/java/com/idevicesinc/sweetblue/BleScanPower.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/BleScanPower.java
@@ -22,25 +22,25 @@ public enum BleScanPower
 
     /**
      * Lollipop-and-up-relevant-only, this is strict typing for {@link ScanSettings#SCAN_MODE_OPPORTUNISTIC}.
-     * For phones lower than Lollipop, this will be used ignored.
+     * For phones lower than Lollipop, this will be ignored.
      */
     VERY_LOW_POWER(ScanSettings.SCAN_MODE_OPPORTUNISTIC),
 
     /**
      * Lollipop-and-up-relevant-only, this is strict typing for {@link ScanSettings#SCAN_MODE_LOW_POWER}.
-     * For phones lower than Lollipop, this will be used ignored.
+     * For phones lower than Lollipop, this will be ignored.
      */
     LOW_POWER(ScanSettings.SCAN_MODE_LOW_POWER),
 
     /**
      * Lollipop-and-up-relevant-only, this is strict typing for {@link ScanSettings#SCAN_MODE_BALANCED}.
-     * For phones lower than Lollipop, this will be used ignored.
+     * For phones lower than Lollipop, this will be ignored.
      */
     MEDIUM_POWER(ScanSettings.SCAN_MODE_BALANCED),
 
     /**
      * Lollipop-and-up-relevant-only, this is strict typing for {@link ScanSettings#SCAN_MODE_LOW_LATENCY}.
-     * For phones lower than Lollipop, this will be used ignored.
+     * For phones lower than Lollipop, this will be ignored.
      */
     HIGH_POWER(ScanSettings.SCAN_MODE_LOW_LATENCY);
 

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_SweetBlueThread.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_SweetBlueThread.java
@@ -1,15 +1,7 @@
 package com.idevicesinc.sweetblue;
 
-
 import java.util.Iterator;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 
 final class P_SweetBlueThread implements P_SweetHandler

--- a/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
+++ b/app/src/main/java/com/idevicesinc/sweetblue/P_Task_Scan.java
@@ -1,8 +1,6 @@
 package com.idevicesinc.sweetblue;
 
 
-import android.util.Log;
-
 import com.idevicesinc.sweetblue.PA_StateTracker.E_Intent;
 import com.idevicesinc.sweetblue.utils.Interval;
 
@@ -31,6 +29,11 @@ final class P_Task_Scan extends PA_Task_RequiresBleOn
 
     @Override protected double getInitialTimeout()
     {
+        // Account for the classic scan boost here, we don't want to count the time doing the classic boost towards the timeout of the BLE scan
+        if (isClassicBoosted())
+        {
+            return m_scanTime + getManager().m_config.scanClassicBoostLength.secs();
+        }
         return m_scanTime;
     }
 
@@ -46,8 +49,8 @@ final class P_Task_Scan extends PA_Task_RequiresBleOn
         }
         else
         {
-            boolean isClassicScan = getManager().m_config.scanApi == BleScanApi.CLASSIC || getManager().m_config.scanMode == BleScanMode.CLASSIC;
-            if (Interval.isEnabled(getManager().m_config.scanClassicBoostLength) && !isClassicScan)
+
+            if (isClassicBoosted())
             {
                 if (!getManager().getScanManager().classicBoost(getManager().m_config.scanClassicBoostLength.secs()))
                 {

--- a/integration/src/androidTest/java/com/idevicesinc/sweetblue/ScanClassicBoostTest.java
+++ b/integration/src/androidTest/java/com/idevicesinc/sweetblue/ScanClassicBoostTest.java
@@ -1,19 +1,16 @@
 package com.idevicesinc.sweetblue;
 
 
-import android.support.test.filters.FlakyTest;
 import android.util.Log;
-
 import com.idevicesinc.sweetblue.utils.Interval;
-
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class ScanClassicTest extends BaseTester<MainActivity>
+
+public class ScanClassicBoostTest extends BaseTester<MainActivity>
 {
     @Override Class getActivityClass()
     {

--- a/integration/src/androidTest/java/com/idevicesinc/sweetblue/ScanTest.java
+++ b/integration/src/androidTest/java/com/idevicesinc/sweetblue/ScanTest.java
@@ -1,0 +1,115 @@
+package com.idevicesinc.sweetblue;
+
+
+import android.util.Log;
+import com.idevicesinc.sweetblue.utils.Interval;
+import org.junit.Test;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class ScanTest extends BaseTester<MainActivity>
+{
+
+    private static final String TAG = "ScanTest";
+
+
+    @Test
+    public void preLollipopScanTest() throws Exception
+    {
+        doScanTest(Interval.TEN_SECS, BleScanApi.PRE_LOLLIPOP, BleScanPower.AUTO, Interval.secs(BleManagerConfig.DEFAULT_SCAN_REPORT_DELAY));
+    }
+
+    @Test
+    public void postLollipopMediumTest() throws Exception
+    {
+        doScanTest(Interval.TEN_SECS, BleScanApi.POST_LOLLIPOP, BleScanPower.MEDIUM_POWER, Interval.secs(BleManagerConfig.DEFAULT_SCAN_REPORT_DELAY));
+    }
+
+    @Test
+    public void postLollipopMediumNoBatchDelayTest() throws Exception
+    {
+        doScanTest(Interval.TEN_SECS, BleScanApi.POST_LOLLIPOP, BleScanPower.MEDIUM_POWER, Interval.DISABLED);
+    }
+
+    @Test
+    public void postLollipopHighTest() throws Exception
+    {
+        doScanTest(Interval.TEN_SECS, BleScanApi.POST_LOLLIPOP, BleScanPower.HIGH_POWER, Interval.secs(BleManagerConfig.DEFAULT_SCAN_REPORT_DELAY));
+    }
+
+    @Test
+    public void postLollipopHighNoBatchDelayTest() throws Exception
+    {
+        doScanTest(Interval.TEN_SECS, BleScanApi.POST_LOLLIPOP, BleScanPower.HIGH_POWER, Interval.DISABLED);
+    }
+
+
+
+    private void doScanTest(Interval scanLength, BleScanApi scanApi, BleScanPower scanPower, Interval batchDelay) throws Exception
+    {
+        final Semaphore s = new Semaphore(0);
+
+        final AtomicInteger deviceCount = new AtomicInteger(0);
+        final AtomicLong timeStarted = new AtomicLong(0);
+        final AtomicLong timeBeforeFirstDeviceDiscovered = new AtomicLong(0);
+        mConfig.scanApi = scanApi;
+        mConfig.scanPower = scanPower;
+        mConfig.scanReportDelay = batchDelay;
+        mgr.setConfig(mConfig);
+
+        mgr.setListener_Discovery(new BleManager.DiscoveryListener()
+        {
+            @Override
+            public void onEvent(DiscoveryEvent e)
+            {
+                if (e.was(LifeCycle.DISCOVERED))
+                {
+                    if (deviceCount.get() == 0)
+                    {
+                        timeBeforeFirstDeviceDiscovered.set(System.currentTimeMillis() - timeStarted.get());
+                    }
+                    deviceCount.incrementAndGet();
+                }
+            }
+        });
+
+        mgr.setListener_State(new ManagerStateListener()
+        {
+            @Override
+            public void onEvent(BleManager.StateListener.StateEvent e)
+            {
+                if (e.didExit(BleManagerState.SCANNING))
+                {
+                    Log.e(TAG, "Pre-Lollipop scan:\nTime to find first device: " + timeBeforeFirstDeviceDiscovered.get() + "ms\n" +
+                            "Scan finished with " + deviceCount.get() + " devices found.");
+                    s.release();
+                }
+                else if (e.didEnter(BleManagerState.SCANNING))
+                {
+                    timeStarted.set(System.currentTimeMillis());
+                }
+            }
+        });
+
+        mgr.startScan(scanLength);
+        s.acquire();
+    }
+
+
+    @Override
+    Class<MainActivity> getActivityClass()
+    {
+        return MainActivity.class;
+    }
+
+    @Override
+    BleManagerConfig getInitialConfig()
+    {
+        BleManagerConfig config = new BleManagerConfig();
+        config.runOnMainThread = false;
+        config.loggingEnabled = true;
+        return null;
+    }
+}


### PR DESCRIPTION
Removed cap of 1 second from update loop, so it reports the proper delta.
Changed defaut scan report delay to be disabled, as it tends to hog the update (SWEET-338)
