### PR TITLE
fix both write stripe transactions to use effective mtu size to split…

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
@@ -5528,6 +5528,16 @@ public final class BleDevice extends BleNode
         return true;
     }
 
+    /**
+     * Returns the effective MTU size for a write. BLE has an overhead when reading and writing, so that eats out of the MTU size.
+     * The write overhead is defined via {@link BleManagerConfig#GATT_WRITE_MTU_OVERHEAD}. The method simply returns the MTU size minus
+     * the overhead. This is just used internally, but is exposed in case it's needed for some other use app-side.
+     */
+    public final int getEffectiveWriteMtuSize()
+    {
+        return getMtu() - BleManagerConfig.GATT_WRITE_MTU_OVERHEAD;
+    }
+
     private boolean performTransaction_earlyOut(final BleTransaction txn)
     {
         if (txn == null) return true;
@@ -6602,11 +6612,6 @@ public final class BleDevice extends BleNode
         }
 
         return NULL_READWRITE_EVENT();
-    }
-
-    private int getEffectiveWriteMtuSize()
-    {
-        return getMtu() - BleManagerConfig.GATT_WRITE_MTU_OVERHEAD;
     }
 
     private void addWriteDescriptorTasks(BluetoothGattDescriptor descriptor, FutureData data, boolean requiresBonding, ReadWriteListener listener)

--- a/library/src/main/java/com/idevicesinc/sweetblue/P_StripedWriteDescriptorTransaction.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_StripedWriteDescriptorTransaction.java
@@ -38,8 +38,8 @@ final class P_StripedWriteDescriptorTransaction extends BleTransaction
         FutureData curData;
         while (curIndex < allData.length)
         {
-            int end = Math.min(allData.length, curIndex + device.getMtu());
-            curData = new PresentData(Arrays.copyOfRange(allData, curIndex, Math.min(allData.length, curIndex + device.getMtu())));
+            int end = Math.min(allData.length, curIndex + device.getEffectiveWriteMtuSize());
+            curData = new PresentData(Arrays.copyOfRange(allData, curIndex, end));
             m_writeList.add(new P_Task_WriteDescriptor(device, m_descriptor, curData, m_requiresBonding, m_internalListener, device.m_txnMngr.getCurrent(), device.getOverrideReadWritePriority()));
             curIndex = end;
         }

--- a/library/src/main/java/com/idevicesinc/sweetblue/P_StripedWriteTransaction.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_StripedWriteTransaction.java
@@ -44,8 +44,8 @@ final class P_StripedWriteTransaction extends BleTransaction
         FutureData curData;
         while (curIndex < allData.length)
         {
-            int end = Math.min(allData.length, curIndex + device.getMtu());
-            curData = new PresentData(Arrays.copyOfRange(allData, curIndex, Math.min(allData.length, curIndex + device.getMtu())));
+            int end = Math.min(allData.length, curIndex + device.getEffectiveWriteMtuSize());
+            curData = new PresentData(Arrays.copyOfRange(allData, curIndex, end));
             final P_Task_Write task;
             if (m_descriptorFilter == null)
             {


### PR DESCRIPTION
… data up, rather than mtu -- which loses 3 bytes on every split, also updated unit test to make sure resulting data is the same