### PR TITLE
set writeType to null in WriteBuilder, and don't set the type on the …

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/P_Task_Write.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_Task_Write.java
@@ -64,18 +64,21 @@ final class P_Task_Write extends PA_Task_ReadOrWrite
 			}
 			else
 			{
-				// Set the write type now.
-				if (m_writeType == Type.WRITE_NO_RESPONSE)
+				// Set the write type now, if it is no null
+				if (m_writeType != null)
 				{
-					char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
-				}
-				else if (m_writeType == Type.WRITE_SIGNED)
-				{
-					char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_SIGNED);
-				}
-				else if (char_native.getWriteType() != BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
-				{
-					char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+					if (m_writeType == Type.WRITE_NO_RESPONSE)
+					{
+						char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE);
+					}
+					else if (m_writeType == Type.WRITE_SIGNED)
+					{
+						char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_SIGNED);
+					}
+					else if (char_native.getWriteType() != BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+					{
+						char_native.setWriteType(BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT);
+					}
 				}
 
 				if( false == getDevice().layerManager().setCharValue(char_native, m_data) )

--- a/library/src/main/java/com/idevicesinc/sweetblue/WriteBuilder.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/WriteBuilder.java
@@ -25,7 +25,7 @@ public final class WriteBuilder
     UUID charUuid = null;
     UUID descriptorUuid = null;
     FutureData data = null;
-    BleDevice.ReadWriteListener.Type writeType = BleDevice.ReadWriteListener.Type.WRITE;
+    BleDevice.ReadWriteListener.Type writeType = null;
     BleDevice.ReadWriteListener readWriteListener = null;
     DescriptorFilter descriptorFilter = null;
     boolean bigEndian = true;


### PR DESCRIPTION
…char unless the type in the builder is not null to avoid always setting chars to write, even if its not supported