### PR TITLE
Add logging to tests, so build server doesnt hit the 10 minute no log…

### DIFF
--- a/tester/build.gradle
+++ b/tester/build.gradle
@@ -20,6 +20,14 @@ android {
     }
 }
 
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+}
+
 repositories {
     mavenCentral()
     maven {


### PR DESCRIPTION
… timeout.