### PR TITLE
Removed default listener from instance field. When processing a conne…

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/P_ConnectionFailManager.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_ConnectionFailManager.java
@@ -17,7 +17,7 @@ final class P_ConnectionFailManager
 	private final BleDevice m_device;
 	
 
-	private DeviceConnectionFailListener m_connectionFailListener = BleDevice.DEFAULT_CONNECTION_FAIL_LISTENER;
+	private DeviceConnectionFailListener m_connectionFailListener = null;
 
 	private int m_failCount = 0;
 	private BleDeviceState m_highestStateReached_total = null;


### PR DESCRIPTION
…ction fail event, it will only pipe back to the manager if the default instance is null (if they're both null, then the static default instance is used). This brings us back to pre v3 behavior. We may want to change this so all events pump out to the manager listener if its not null