### PR TITLE
Also takes care of SWEET-462

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_BleManager_Listeners.java
@@ -255,17 +255,29 @@ final class P_BleManager_Listeners
         }
     }
 
-    private void onClassicDiscoveryFinished()
+    void onClassicDiscoveryFinished()
     {
         P_Task_Scan scanTask = m_mngr.getTaskQueue().getCurrent(P_Task_Scan.class, m_mngr);
+        boolean interrupt = false;
         if (scanTask != null)
         {
             if (scanTask.isClassicBoosted())
             {
                 return;
             }
+            if (m_mngr.getScanManager().isPeriodicScan())
+                interrupt = true;
+
         }
-        m_mngr.getTaskQueue().interrupt(P_Task_Scan.class, m_mngr);
+        if (interrupt)
+            m_mngr.getTaskQueue().interrupt(P_Task_Scan.class, m_mngr);
+        else
+            // Try to succeed the task, if that fails, it means it's no longer current, so we'll clear the queue of the scan task, just to be sure it doesn't
+            // start up again
+            if (!m_mngr.getTaskQueue().succeed(P_Task_Scan.class, m_mngr))
+            {
+                m_mngr.getTaskQueue().clearQueueOf(P_Task_Scan.class, m_mngr);
+            }
     }
 
     final void onNativeBleStateChangeFromBroadcastReceiver(Context context, Intent intent)

--- a/library/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_ScanManager.java
@@ -104,7 +104,7 @@ final class P_ScanManager
                 {
                     m_manager.getLogger().e("Tried to start BLE scan, but scanning is not ready (most likely need to get permissions). Falling back to classic discovery.");
                     mCurrentApi.set(BleScanApi.CLASSIC);
-                    return tryClassicDiscovery(intent, true);
+                    return tryClassicDiscovery(PA_StateTracker.E_Intent.UNINTENTIONAL, true);
                 }
             case AUTO:
             case PRE_LOLLIPOP:
@@ -565,7 +565,7 @@ final class P_ScanManager
         {
             m_manager.getLogger().w("Pre-Lollipop LeScan totally failed to start!");
 
-            tryClassicDiscovery(intent, /*suppressUhOh=*/false);
+            tryClassicDiscovery(PA_StateTracker.E_Intent.UNINTENTIONAL, /*suppressUhOh=*/false);
             return true;
         }
         else
@@ -646,7 +646,8 @@ final class P_ScanManager
 
     private boolean tryClassicDiscovery(final PA_StateTracker.E_Intent intent, final boolean suppressUhOh)
     {
-        if (m_manager.m_config.revertToClassicDiscoveryIfNeeded)
+        boolean intentional = intent == PA_StateTracker.E_Intent.INTENTIONAL;
+        if (intentional || m_manager.m_config.revertToClassicDiscoveryIfNeeded)
         {
             if (false == startClassicDiscovery())
             {
@@ -841,7 +842,7 @@ final class P_ScanManager
             }
             else
             {
-                tryClassicDiscovery(PA_StateTracker.E_Intent.INTENTIONAL, /*suppressUhOh=*/false);
+                tryClassicDiscovery(PA_StateTracker.E_Intent.UNINTENTIONAL, /*suppressUhOh=*/false);
 
                 m_mode = Mode_CLASSIC;
             }

--- a/sweetunit/src/main/java/com/idevicesinc/sweetblue/UnitTestManagerLayer.java
+++ b/sweetunit/src/main/java/com/idevicesinc/sweetblue/UnitTestManagerLayer.java
@@ -40,6 +40,7 @@ public class UnitTestManagerLayer implements P_NativeManagerLayer
 
     @Override public boolean cancelDiscovery()
     {
+        BleManager.s_instance.m_listeners.onClassicDiscoveryFinished();
         return true;
     }
 

--- a/tester/src/test/java/com/idevicesinc/sweetblue/ScanTest.java
+++ b/tester/src/test/java/com/idevicesinc/sweetblue/ScanTest.java
@@ -76,6 +76,33 @@ public class ScanTest extends BaseBleUnitTest
         });
     }
 
+    @Test
+    public void scanClassicOneTimeTest() throws Exception
+    {
+        m_config.scanApi = BleScanApi.CLASSIC;
+        m_config.loggingEnabled = true;
+        m_mgr.setConfig(m_config);
+        m_mgr.setListener_State(new ManagerStateListener()
+        {
+            @Override
+            public void onEvent(BleManager.StateListener.StateEvent e)
+            {
+                if (e.didEnter(BleManagerState.SCANNING))
+                {
+                    assertTrue("Scan Api: " + getScanApi().name(), getScanApi() == BleScanApi.CLASSIC);
+                }
+                else if (e.didExit(BleManagerState.SCANNING))
+                {
+                    assertFalse("Scan task is in the queue, when it should not be!", m_mgr.getTaskQueue().isInQueue(P_Task_Scan.class, m_mgr) || m_mgr.getTaskQueue().isCurrent(P_Task_Scan.class, m_mgr));
+                    succeed();
+                }
+            }
+        });
+
+        m_mgr.startScan(Interval.FIVE_SECS);
+        startTest();
+    }
+
     @Test(timeout = 10000)
     public void scanApiPreLollipop() throws Exception
     {


### PR DESCRIPTION
Now the revert option is only honored when performing a classic scan as a fallback. If it's false and you manually start a classic scan, it will now work.
Clear the scan task if it's a classic scan, and not periodic (otherwise we interrupt, so it can start again).