### PR TITLE
Add null guard in startScan method to prevent NPEs when starting a sc…

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/compat/L_Util.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/compat/L_Util.java
@@ -211,6 +211,13 @@ public class L_Util
 
     static void startScan(BluetoothAdapter adapter, ScanSettings scanSettings, ScanCallback listener) {
         m_UserCallback = listener;
+        // Add a last ditch check to make sure the adapter isn't null before trying to start the scan.
+        // We check in the task, but by the time we reach this method, it could have been shut off
+        if (adapter == null)
+        {
+            m_callback.onScanFailed(android.bluetooth.le.ScanCallback.SCAN_FAILED_INTERNAL_ERROR);
+            return;
+        }
         adapter.getBluetoothLeScanner().startScan(null, scanSettings, m_callback);
     }
 


### PR DESCRIPTION
…an. The task already checks if BT is enabled, so this is a race condition.