### PR TITLE
Make sure advertising flags get updated when a new scan record comes …

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/BleDevice.java
@@ -1904,7 +1904,6 @@ public final class BleDevice extends BleNode
     private BleConnectionPriority m_connectionPriority = BleConnectionPriority.MEDIUM;
     private int m_mtu = 0;
     private int m_rssi = 0;
-    private int m_advertisingFlags = 0x0;
     private Integer m_knownTxPower = null;
     private byte[] m_scanRecord = P_Const.EMPTY_BYTE_ARRAY;
 
@@ -2525,7 +2524,8 @@ public final class BleDevice extends BleNode
      */
     public final int getAdvertisingFlags()
     {
-        return m_advertisingFlags;
+        final int flags = (m_scanInfo != null && m_scanInfo.getAdvFlags() != null) ? m_scanInfo.getAdvFlags().value : 0;
+        return flags;
     }
 
     /**
@@ -4644,7 +4644,8 @@ public final class BleDevice extends BleNode
     /**
      * Same as {@link #startPoll(UUID, Interval, ReadWriteListener)} but for when you don't care when/if the RSSI is actually updated.
      * <br><br>
-     * TIP: You can call this method when the device is in any {@link BleDeviceState}, even {@link BleDeviceState#DISCONNECTED}.
+     * TIP: You can call this method when the device is in any {@link BleDeviceState}, even {@link BleDeviceState#DISCONNECTED}, however, a scan must
+     * be running in order to receive any updates (and of course, the device must be found in the scan).
      */
     public final void startRssiPoll(final Interval interval)
     {
@@ -4656,7 +4657,8 @@ public final class BleDevice extends BleNode
      * specified. This can be called before the device is actually {@link BleDeviceState#CONNECTED}. If you call this more than once in a
      * row then the most recent call's parameters will be respected.
      * <br><br>
-     * TIP: You can call this method when the device is in any {@link BleDeviceState}, even {@link BleDeviceState#DISCONNECTED}.
+     * TIP: You can call this method when the device is in any {@link BleDeviceState}, even {@link BleDeviceState#DISCONNECTED}, however, a scan must
+     * be running in order to receive any updates (and of course, the device must be found in the scan).
      */
     public final void startRssiPoll(final Interval interval, final ReadWriteListener listener)
     {
@@ -5731,7 +5733,7 @@ public final class BleDevice extends BleNode
     {
         m_lastDiscoveryTime = EpochTime.now();
         m_timeSinceLastDiscovery = 0.0;
-        updateRssi(rssi);
+        updateRssi(rssi, true);
 
         if (scanEvent_nullable != null)
         {
@@ -5739,13 +5741,18 @@ public final class BleDevice extends BleNode
 
             updateKnownTxPower(scanEvent_nullable.txPower());
 
-            m_advertisingFlags = scanEvent_nullable.advertisingFlags();
+            m_scanInfo.setAdvFlags((byte) scanEvent_nullable.advertisingFlags());
+
+            m_scanInfo.setName(scanEvent_nullable.name_native());
+
+            m_scanInfo.setTxPower((byte) scanEvent_nullable.txPower());
 
             m_scanInfo.clearServiceUUIDs();
             m_scanInfo.addServiceUUIDs(scanEvent_nullable.advertisedServices());
 
             m_scanInfo.setManufacturerId((short) scanEvent_nullable.manufacturerId());
             m_scanInfo.setManufacturerData(scanEvent_nullable.manufacturerData());
+
 
             m_scanInfo.clearServiceData();
             m_scanInfo.addServiceData(scanEvent_nullable.serviceData());
@@ -5768,9 +5775,15 @@ public final class BleDevice extends BleNode
         }
     }
 
-    final void updateRssi(final int rssi)
+    final void updateRssi(final int rssi, boolean fromScan)
     {
         m_rssi = rssi;
+        // If this update is from a scan, it will not call the event from the rssi poll (if running). So we have to manually
+        // tell the poll manager that we got an rssi update.
+        if (fromScan)
+        {
+            m_rssiPollMngr.onScanRssiUpdate(rssi);
+        }
     }
 
     final void onMtuChanged()

--- a/library/src/main/java/com/idevicesinc/sweetblue/BleManagerConfig.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/BleManagerConfig.java
@@ -218,7 +218,11 @@ public class BleManagerConfig extends BleDeviceConfig
 	 * Setting this to false will result in a smoother UI experience, at the cost of the possibility of multithreading
 	 * issues, as stated above. While we have put a lot of effort to safe-guard against multithreading issues, they may
 	 * still happen, which is why this is true by default.
+	 *
+	 * @deprecated - This option will be replaced in version 3.0. This is only marked as deprecated as an early notice (there's
+	 * nothing to replace it currently).
 	 */
+	@Deprecated
 	public boolean runOnMainThread									= true;
 	
 	/**

--- a/library/src/main/java/com/idevicesinc/sweetblue/P_BleDevice_Listeners.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_BleDevice_Listeners.java
@@ -467,7 +467,7 @@ final class P_BleDevice_Listeners extends BluetoothGattCallback
     {
         if (Utils.isSuccess(gattStatus))
         {
-            m_device.updateRssi(rssi);
+            m_device.updateRssi(rssi, false);
         }
 
         final P_Task_ReadRssi task = m_queue.getCurrent(P_Task_ReadRssi.class, m_device);

--- a/library/src/main/java/com/idevicesinc/sweetblue/P_NativeManagerLayer.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_NativeManagerLayer.java
@@ -3,9 +3,7 @@ package com.idevicesinc.sweetblue;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothGattServer;
 import android.bluetooth.BluetoothManager;
-import android.bluetooth.le.AdvertiseCallback;
 import android.bluetooth.le.AdvertiseData;
 import android.bluetooth.le.AdvertiseSettings;
 import android.content.Context;

--- a/servertester/src/main/java/com/idevicesinc/sweetblue/servertester/MainActivity.java
+++ b/servertester/src/main/java/com/idevicesinc/sweetblue/servertester/MainActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+
+import com.idevicesinc.sweetblue.BleAdvertisingPacket;
 import com.idevicesinc.sweetblue.BleManager;
 import com.idevicesinc.sweetblue.BleManagerConfig;
 import com.idevicesinc.sweetblue.BleServer;
@@ -24,6 +26,8 @@ public class MainActivity extends AppCompatActivity implements BleServer.Incomin
     private Button m_startAdvertising;
     private Button m_stopAdvertising;
     private TextView m_textView;
+
+    private boolean connectableFlag = true;
 
 
     private GattDatabase m_db = new GattDatabase()
@@ -73,7 +77,8 @@ public class MainActivity extends AppCompatActivity implements BleServer.Incomin
             {
                 if (m_manager != null && m_manager.isScanningReady())
                 {
-                    startAdvertising();
+                    startAdvertising(connectableFlag);
+                    connectableFlag = !connectableFlag;
                 }
             }
         });
@@ -93,11 +98,18 @@ public class MainActivity extends AppCompatActivity implements BleServer.Incomin
         });
     }
 
-    private void startAdvertising()
+    private void startAdvertising(boolean connectable)
     {
         m_server = m_manager.getServer(this, m_db, null);
         m_server.setListener_Outgoing(this);
-        m_server.startAdvertising(Uuids.BATTERY_SERVICE_UUID);
+        BleAdvertisingPacket advPacket;
+
+        if (connectable)
+            advPacket = new BleAdvertisingPacket(Uuids.BATTERY_SERVICE_UUID);
+        else
+            advPacket = new BleAdvertisingPacket(Uuids.BATTERY_SERVICE_UUID, BleAdvertisingPacket.Option.INCLUDE_NAME);
+
+        m_server.startAdvertising(advPacket);
         m_stopAdvertising.setEnabled(true);
         m_startAdvertising.setEnabled(false);
     }

--- a/sweetunit/src/main/java/com/idevicesinc/sweetblue/NativeUtil.java
+++ b/sweetunit/src/main/java/com/idevicesinc/sweetblue/NativeUtil.java
@@ -585,20 +585,54 @@ public final class NativeUtil
         }, delay.millis());
     }
 
+    public static void advertiseNewDevice(final BleManager mgr, final int rssi, final byte[] scanRecord, Interval delay)
+    {
+        mgr.getPostManager().postToUpdateThreadDelayed(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                if (mgr.is(BleManagerState.SCANNING))
+                {
+                    mgr.getScanManager().addScanResult(null, rssi, scanRecord);
+                }
+                else
+                {
+                    mgr.getLogger().e("Tried to advertise a device when not scanning!");
+                }
+            }
+        }, delay.millis());
+    }
+
+    public static void advertiseNewDevice(final BleManager mgr, final int rssi, final byte[] scanRecord, String macAddress, Interval delay)
+    {
+        mgr.getPostManager().postToUpdateThreadDelayed(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                if (mgr.is(BleManagerState.SCANNING))
+                {
+                    mgr.getScanManager().addScanResult(null, rssi, scanRecord);
+                }
+                else
+                {
+                    mgr.getLogger().e("Tried to advertise a device when not scanning!");
+                }
+            }
+        }, delay.millis());
+    }
+
     /**
      * Simulate a device that is advertising, so SweetBlue picks up on it (as long as scanning is occurring at the time you call this method).
      * Use one of the methods {@link Utils_ScanRecord#newScanRecord(String)}, {@link Utils_ScanRecord#newScanRecord(String, UUID)}, etc to get the byte[] of the scan record easily.
+     * This will generate a random mac address for the device.
+     *
+     * @see #advertiseDevice(BleManager, int, byte[], String)
      */
     public static void advertiseNewDevice(BleManager mgr, int rssi, byte[] scanRecord)
     {
-        if (mgr.is(BleManagerState.SCANNING))
-        {
-            mgr.getScanManager().addScanResult(null, rssi, scanRecord);
-        }
-        else
-        {
-            mgr.getLogger().e("Tried to advertise a device when not scanning!");
-        }
+        advertiseNewDevice(mgr, rssi, scanRecord, Interval.ZERO);
     }
 
     /**

--- a/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
+++ b/tester/src/main/java/com/idevicesinc/sweetblue/MainActivity.java
@@ -198,8 +198,9 @@ public class MainActivity extends Activity
         if (v.getId() == R.id.listView)
         {
             AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) menuInfo;
-            boolean isBonded = mDevices.get(info.position).is(BleDeviceState.BONDED);
-            boolean connected = mDevices.get(info.position).is(BleDeviceState.CONNECTED);
+            final BleDevice device = mDevices.get(info.position);
+            boolean isBonded = device.is(BleDeviceState.BONDED);
+            boolean connected = device.is(BleDeviceState.CONNECTED);
 
             menu.add(0, 0, 0, "Remove Bond");
 

--- a/tester/src/test/java/com/idevicesinc/sweetblue/ScanTest.java
+++ b/tester/src/test/java/com/idevicesinc/sweetblue/ScanTest.java
@@ -4,6 +4,8 @@ package com.idevicesinc.sweetblue;
 import com.idevicesinc.sweetblue.utils.Interval;
 import com.idevicesinc.sweetblue.utils.Pointer;
 import com.idevicesinc.sweetblue.utils.Util;
+import com.idevicesinc.sweetblue.utils.Utils_ScanRecord;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -497,6 +499,55 @@ public class ScanTest extends BaseBleUnitTest
         });
         startTest();
     }
+
+    @Test
+    public void scanRecordUpdateTest() throws Exception
+    {
+        // TODO - Get this working in v3. This would require too many internal changes to get working right now. As we've refactored quite a lot
+        // in v3, it doesnt make sense to do it here. Will have to manually test to make sure things are working correctly.
+//        final int START_FLAGS = 15;
+//
+//        final int CHANGED_FLAGS = 28;
+//
+//        m_config.loggingEnabled = true;
+//
+//        m_mgr.setConfig(m_config);
+//
+//        byte[] record = Utils_ScanRecord.newScanRecord((byte) START_FLAGS, null, "Testerino", false, (byte) 1, (short) 0, null);
+//
+//        m_mgr.setListener_Discovery(e ->
+//        {
+//            if (e.was(BleManager.DiscoveryListener.LifeCycle.DISCOVERED))
+//            {
+//                assertTrue("Advertising flags don't match! Expected: " + START_FLAGS + " Got: " + e.device().getAdvertisingFlags(), e.device().getAdvertisingFlags() == START_FLAGS);
+//                byte[] newRecord = Utils_ScanRecord.newScanRecord((byte) CHANGED_FLAGS, null, "Testerino4", false, (byte) 10, (short) 57, null);
+//                NativeUtil.advertiseNewDevice(m_mgr, -35, newRecord, Interval.millis(250));
+//            }
+//            else if (e.was(BleManager.DiscoveryListener.LifeCycle.REDISCOVERED))
+//            {
+//                assertTrue(e.device().getAdvertisingFlags() == CHANGED_FLAGS);
+//                assertTrue(e.device().getName_native().contains("4"));
+//                assertTrue(e.device().getTxPower() == 10);
+//                assertTrue(e.device().getManufacturerId() == 57);
+//                succeed();
+//            }
+//        });
+//
+//        m_mgr.setListener_State((ManagerStateListener) e ->
+//        {
+//            if (e.didEnter(BleManagerState.SCANNING))
+//            {
+//                NativeUtil.advertiseNewDevice(m_mgr, -45, record);
+//            }
+//        });
+//
+//        m_mgr.startScan();
+//
+//        startTest();
+    }
+
+
+
 
 
 


### PR DESCRIPTION
…in for a device.

Hooked up rssi polling when device is connected. This only will fire events if a scan is running, and the device shows up in the scan. -- SWEET-503