### PR TITLE
Small code formatting fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Getting Started
     			});
     		}
     	}
-};
+    };
     
     // This class helps you navigate the treacherous waters of Android M Location requirements for scanning.
     // First it enables bluetooth itself, then location permissions, then location services. The latter two


### PR DESCRIPTION
A very small code formatting fix in the REARME. One parenthesis was not spaced out correctly. 