### PR TITLE
Fixed race condition in P_TaskQueue update

### DIFF
--- a/library/src/main/java/com/idevicesinc/sweetblue/P_TaskQueue.java
+++ b/library/src/main/java/com/idevicesinc/sweetblue/P_TaskQueue.java
@@ -241,10 +241,10 @@ final class P_TaskQueue
 	public final boolean update(double timeStep, long currentTime)
 	{
 		boolean executingTask = false;
-
+		PA_Task task = getCurrent();
 		m_time += timeStep;
 
-		if (getCurrent() == null)
+		if (task == null)
 			m_timeSinceEnding += timeStep;
 
 		if( m_executeHandler == null )
@@ -254,14 +254,14 @@ final class P_TaskQueue
 			return executingTask;
 		}
 
-		if( getCurrent() == null )
+		if( task == null )
 		{
 			executingTask = dequeue();
 		}
 
-		if( getCurrent() != null )
+		if( task != null )
 		{
-			getCurrent().update_internal(timeStep, currentTime);
+			task.update_internal(timeStep, currentTime);
 			executingTask = true;
 		}
 


### PR DESCRIPTION
While using SweetBlue for a project, this issue was encountered using version 2.52.15:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.idevicesinc.sweetblue.PA_Task.update_internal(double, long)' on a null object reference
       at com.idevicesinc.sweetblue.P_TaskQueue.update(P_TaskQueue.java:264)
       at com.idevicesinc.sweetblue.BleManager.update(BleManager.java:3454)
       at com.idevicesinc.sweetblue.BleManager$UpdateRunnable.run(BleManager.java:3645)
       at com.idevicesinc.sweetblue.P_SweetBlueThread$SweetRunnable.run(P_SweetBlueThread.java:87)
       at com.idevicesinc.sweetblue.P_SweetBlueThread$HandlerRunner.run(P_SweetBlueThread.java:128)
       at java.lang.Thread.run(Thread.java:818)
```

The core issue was after calling `getCurrent()` at line 263, the next time it was called at 264, the return is null which causes the crash. The proposed solution is calling `getCurrent()`only once this function and use the results for the rest to the function call.