### PR TITLE
Android Studio 3.1 Released on Stable Channel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'commons-codec:commons-codec:1.8'
         //classpath 'org.apache.ant:ant-jsch:1.7.1', 'jsch:jsch:0.1.29'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 01 11:46:49 EDT 2017
+#Tue Mar 27 12:45:46 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
# Summary
- Upped gradle android plugin to 3.1.0 and gradle version to 4.6
- this was because Android Studio 3.1 had released on the stable channel and developers are asked to update the plugin in the IDE